### PR TITLE
Fix crash on Health Connect rate limit error (#116)

### DIFF
--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataOperations.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataOperations.kt
@@ -54,12 +54,17 @@ class HealthDataOperations(
         }
 
         scope.launch {
-            result.success(
-                    healthConnectClient
-                            .permissionController
-                            .getGrantedPermissions()
-                            .containsAll(permList),
-            )
+            try {
+                result.success(
+                        healthConnectClient
+                                .permissionController
+                                .getGrantedPermissions()
+                                .containsAll(permList),
+                )
+            } catch (e: Exception) {
+                Log.e("FLUTTER_HEALTH::ERROR", "Error checking permissions: ${e.message}")
+                result.success(false)
+            }
         }
     }
 
@@ -89,8 +94,12 @@ class HealthDataOperations(
      */
     fun revokePermissions(call: MethodCall, result: Result) {
         scope.launch {
-            Log.i("FLUTTER_HEALTH", "Revoking all Health Connect permissions")
-            healthConnectClient.permissionController.revokeAllPermissions()
+            try {
+                Log.i("FLUTTER_HEALTH", "Revoking all Health Connect permissions")
+                healthConnectClient.permissionController.revokeAllPermissions()
+            } catch (e: Exception) {
+                Log.e("FLUTTER_HEALTH::ERROR", "Error revoking permissions: ${e.message}")
+            }
         }
         result.success(true)
     }
@@ -104,11 +113,16 @@ class HealthDataOperations(
      */
     fun isHealthDataHistoryAvailable(call: MethodCall, result: Result) {
         scope.launch {
-            result.success(
-                    healthConnectClient.features.getFeatureStatus(
-                            HealthConnectFeatures.FEATURE_READ_HEALTH_DATA_HISTORY
-                    ) == HealthConnectFeatures.FEATURE_STATUS_AVAILABLE
-            )
+            try {
+                result.success(
+                        healthConnectClient.features.getFeatureStatus(
+                                HealthConnectFeatures.FEATURE_READ_HEALTH_DATA_HISTORY
+                        ) == HealthConnectFeatures.FEATURE_STATUS_AVAILABLE
+                )
+            } catch (e: Exception) {
+                Log.e("FLUTTER_HEALTH::ERROR", "Error checking health data history availability: ${e.message}")
+                result.success(false)
+            }
         }
     }
 
@@ -121,12 +135,17 @@ class HealthDataOperations(
      */
     fun isHealthDataHistoryAuthorized(call: MethodCall, result: Result) {
         scope.launch {
-            result.success(
-                    healthConnectClient
-                            .permissionController
-                            .getGrantedPermissions()
-                            .containsAll(listOf(PERMISSION_READ_HEALTH_DATA_HISTORY)),
-            )
+            try {
+                result.success(
+                        healthConnectClient
+                                .permissionController
+                                .getGrantedPermissions()
+                                .containsAll(listOf(PERMISSION_READ_HEALTH_DATA_HISTORY)),
+                )
+            } catch (e: Exception) {
+                Log.e("FLUTTER_HEALTH::ERROR", "Error checking health data history authorization: ${e.message}")
+                result.success(false)
+            }
         }
     }
 
@@ -139,11 +158,16 @@ class HealthDataOperations(
      */
     fun isHealthDataInBackgroundAvailable(call: MethodCall, result: Result) {
         scope.launch {
-            result.success(
-                    healthConnectClient.features.getFeatureStatus(
-                            HealthConnectFeatures.FEATURE_READ_HEALTH_DATA_IN_BACKGROUND
-                    ) == HealthConnectFeatures.FEATURE_STATUS_AVAILABLE
-            )
+            try {
+                result.success(
+                        healthConnectClient.features.getFeatureStatus(
+                                HealthConnectFeatures.FEATURE_READ_HEALTH_DATA_IN_BACKGROUND
+                        ) == HealthConnectFeatures.FEATURE_STATUS_AVAILABLE
+                )
+            } catch (e: Exception) {
+                Log.e("FLUTTER_HEALTH::ERROR", "Error checking background data availability: ${e.message}")
+                result.success(false)
+            }
         }
     }
 
@@ -156,12 +180,17 @@ class HealthDataOperations(
      */
     fun isHealthDataInBackgroundAuthorized(call: MethodCall, result: Result) {
         scope.launch {
-            result.success(
-                    healthConnectClient
-                            .permissionController
-                            .getGrantedPermissions()
-                            .containsAll(listOf(PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND)),
-            )
+            try {
+                result.success(
+                        healthConnectClient
+                                .permissionController
+                                .getGrantedPermissions()
+                                .containsAll(listOf(PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND)),
+                )
+            } catch (e: Exception) {
+                Log.e("FLUTTER_HEALTH::ERROR", "Error checking background data authorization: ${e.message}")
+                result.success(false)
+            }
         }
     }
 

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
@@ -388,73 +388,78 @@ class HealthDataReader(
         for (rec in filteredRecords) {
             val record = rec as ExerciseSessionRecord
             
-            // Get distance data
-            val distanceRequest = healthConnectClient.readRecords(
-                ReadRecordsRequest(
-                    recordType = DistanceRecord::class,
-                    timeRangeFilter = TimeRangeFilter.between(
-                        record.startTime,
-                        record.endTime,
+            try {
+                // Get distance data
+                val distanceRequest = healthConnectClient.readRecords(
+                    ReadRecordsRequest(
+                        recordType = DistanceRecord::class,
+                        timeRangeFilter = TimeRangeFilter.between(
+                            record.startTime,
+                            record.endTime,
+                        ),
                     ),
-                ),
-            )
-            var totalDistance = 0.0
-            for (distanceRec in distanceRequest.records) {
-                totalDistance += distanceRec.distance.inMeters
-            }
+                )
+                var totalDistance = 0.0
+                for (distanceRec in distanceRequest.records) {
+                    totalDistance += distanceRec.distance.inMeters
+                }
 
-            // Get energy burned data
-            val energyBurnedRequest = healthConnectClient.readRecords(
-                ReadRecordsRequest(
-                    recordType = TotalCaloriesBurnedRecord::class,
-                    timeRangeFilter = TimeRangeFilter.between(
-                        record.startTime,
-                        record.endTime,
+                // Get energy burned data
+                val energyBurnedRequest = healthConnectClient.readRecords(
+                    ReadRecordsRequest(
+                        recordType = TotalCaloriesBurnedRecord::class,
+                        timeRangeFilter = TimeRangeFilter.between(
+                            record.startTime,
+                            record.endTime,
+                        ),
                     ),
-                ),
-            )
-            var totalEnergyBurned = 0.0
-            for (energyBurnedRec in energyBurnedRequest.records) {
-                totalEnergyBurned += energyBurnedRec.energy.inKilocalories
-            }
+                )
+                var totalEnergyBurned = 0.0
+                for (energyBurnedRec in energyBurnedRequest.records) {
+                    totalEnergyBurned += energyBurnedRec.energy.inKilocalories
+                }
 
-            // Get steps data
-            val stepRequest = healthConnectClient.readRecords(
-                ReadRecordsRequest(
-                    recordType = StepsRecord::class,
-                    timeRangeFilter = TimeRangeFilter.between(
-                        record.startTime,
-                        record.endTime
+                // Get steps data
+                val stepRequest = healthConnectClient.readRecords(
+                    ReadRecordsRequest(
+                        recordType = StepsRecord::class,
+                        timeRangeFilter = TimeRangeFilter.between(
+                            record.startTime,
+                            record.endTime
+                        ),
                     ),
-                ),
-            )
-            var totalSteps = 0.0
-            for (stepRec in stepRequest.records) {
-                totalSteps += stepRec.count
-            }
+                )
+                var totalSteps = 0.0
+                for (stepRec in stepRequest.records) {
+                    totalSteps += stepRec.count
+                }
 
-            // Add final datapoint
-            healthConnectData.add(
-                mapOf<String, Any?>(
-                    "uuid" to record.metadata.id,
-                    "workoutActivityType" to
-                            (HealthConstants.workoutTypeMap
-                                .filterValues { it == record.exerciseType }
-                                .keys
-                                .firstOrNull() ?: "OTHER"),
-                    "totalDistance" to if (totalDistance == 0.0) null else totalDistance,
-                    "totalDistanceUnit" to "METER",
-                    "totalEnergyBurned" to if (totalEnergyBurned == 0.0) null else totalEnergyBurned,
-                    "totalEnergyBurnedUnit" to "KILOCALORIE",
-                    "totalSteps" to if (totalSteps == 0.0) null else totalSteps,
-                    "totalStepsUnit" to "COUNT",
-                    "unit" to "MINUTES",
-                    "date_from" to record.startTime.toEpochMilli(),
-                    "date_to" to record.endTime.toEpochMilli(),
-                    "source_id" to "",
-                    "source_name" to record.metadata.dataOrigin.packageName,
-                ),
-            )
+                // Add final datapoint
+                healthConnectData.add(
+                    mapOf<String, Any?>(
+                        "uuid" to record.metadata.id,
+                        "workoutActivityType" to
+                                (HealthConstants.workoutTypeMap
+                                    .filterValues { it == record.exerciseType }
+                                    .keys
+                                    .firstOrNull() ?: "OTHER"),
+                        "totalDistance" to if (totalDistance == 0.0) null else totalDistance,
+                        "totalDistanceUnit" to "METER",
+                        "totalEnergyBurned" to if (totalEnergyBurned == 0.0) null else totalEnergyBurned,
+                        "totalEnergyBurnedUnit" to "KILOCALORIE",
+                        "totalSteps" to if (totalSteps == 0.0) null else totalSteps,
+                        "totalStepsUnit" to "COUNT",
+                        "unit" to "MINUTES",
+                        "date_from" to record.startTime.toEpochMilli(),
+                        "date_to" to record.endTime.toEpochMilli(),
+                        "source_id" to "",
+                        "source_name" to record.metadata.dataOrigin.packageName,
+                    ),
+                )
+            } catch (e: Exception) {
+                Log.e("FLUTTER_HEALTH::ERROR", "Error reading workout data for record ${record.metadata.id}: ${e.message}")
+                continue
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Add try-catch blocks to prevent app crashes when Health Connect returns rate limit errors (`android.os.RemoteException`).

Closes #116

## Changes

### `HealthDataOperations.kt`
- Added try-catch to permission-related methods that were missing error handling:
  - `hasPermissions()`
  - `revokePermissions()`
  - `isHealthDataHistoryAvailable()`
  - `isHealthDataHistoryAuthorized()`
  - `isHealthDataInBackgroundAvailable()`
  - `isHealthDataInBackgroundAuthorized()`

### `HealthDataReader.kt`
- Added try-catch in `handleWorkoutData()` to gracefully skip workout records that fail to fetch associated data (distance, energy, steps)

## Behavior
- On error: returns `false` or skips the problematic record instead of crashing
- All errors are logged for debugging purposes