### PR TITLE
Add support for MINDFULNESS health data type.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation(composeBom)
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.2.10"
 
-    implementation("androidx.health.connect:connect-client:1.1.0-rc03")
+    implementation("androidx.health.connect:connect-client:1.2.0-alpha01")
     implementation "androidx.fragment:fragment-ktx:1.8.9"
 
 }

--- a/android/src/main/kotlin/cachet/plugins/health/HealthConstants.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthConstants.kt
@@ -30,6 +30,7 @@ object HealthConstants {
     const val HEART_RATE_VARIABILITY_RMSSD = "HEART_RATE_VARIABILITY_RMSSD"
     const val HEIGHT = "HEIGHT"
     const val MENSTRUATION_FLOW = "MENSTRUATION_FLOW"
+    const val MINDFULNESS = "MINDFULNESS"
     const val RESPIRATORY_RATE = "RESPIRATORY_RATE"
     const val RESTING_HEART_RATE = "RESTING_HEART_RATE"
     const val STEPS = "STEPS"
@@ -102,6 +103,7 @@ object HealthConstants {
         RESPIRATORY_RATE to RespiratoryRateRecord::class,
         TOTAL_CALORIES_BURNED to TotalCaloriesBurnedRecord::class,
         MENSTRUATION_FLOW to MenstruationFlowRecord::class,
+        MINDFULNESS to MindfulnessSessionRecord::class,
         SPEED to SpeedRecord::class,
     )
     

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataWriter.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataWriter.kt
@@ -745,6 +745,17 @@ class HealthDataWriter(
                             zoneOffset = null,
                             metadata = metadata,
                     )
+            MINDFULNESS ->
+                    MindfulnessSessionRecord(
+                            startTime = Instant.ofEpochMilli(startTime),
+                            endTime = Instant.ofEpochMilli(endTime),
+                            startZoneOffset = null,
+                            endZoneOffset = null,
+                            mindfulnessSessionType = MindfulnessSessionRecord.MINDFULNESS_SESSION_TYPE_MEDITATION,
+                            metadata = metadata,
+                            title = "",
+                            notes = "",
+                    )
             SPEED ->
                     SpeedRecord(
                             startTime = Instant.ofEpochMilli(startTime),
@@ -841,6 +852,7 @@ class HealthDataWriter(
         private const val RESPIRATORY_RATE = "RESPIRATORY_RATE"
         private const val TOTAL_CALORIES_BURNED = "TOTAL_CALORIES_BURNED"
         private const val MENSTRUATION_FLOW = "MENSTRUATION_FLOW"
+        private const val MINDFULNESS = "MINDFULNESS"
         private const val BLOOD_PRESSURE_SYSTOLIC = "BLOOD_PRESSURE_SYSTOLIC"
         private const val BLOOD_PRESSURE_DIASTOLIC = "BLOOD_PRESSURE_DIASTOLIC"
         private const val WORKOUT = "WORKOUT"

--- a/lib/src/heath_data_types.dart
+++ b/lib/src/heath_data_types.dart
@@ -263,6 +263,7 @@ const List<HealthDataType> dataTypeKeysAndroid = [
   HealthDataType.NUTRITION,
   HealthDataType.TOTAL_CALORIES_BURNED,
   HealthDataType.MENSTRUATION_FLOW,
+  HealthDataType.MINDFULNESS,
 ];
 
 /// Maps a [HealthDataType] to a [HealthDataUnit].


### PR DESCRIPTION
## Summary
Adds support for the `MINDFULNESS` health data type for tracking meditation sessions which is now fully supported on the latest Google Health Connect client dependency.

## Changes
### HealthConstants.kt
Added the new `MINDFULNESS` data type constant and `mapToType` entry for it.

### HealthDataWriter.kt
Added a new record object creator for `MINDFULNESS` to the `createRecord` factory.

### health_data_types.dart
Added `MINDFULNESS` to the list of data types for Android - `dataTypeKeysAndroid`.

## Behavior
Gives the ability to log `MINDFULNESS` minutes to Google Health Connect using this plugin.