### PR TITLE
Fix unnecessary Health Connect permission requirements when reading workouts

### DIFF
--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
@@ -388,49 +388,67 @@ class HealthDataReader(
         for (rec in filteredRecords) {
             val record = rec as ExerciseSessionRecord
             
-            // Get distance data
-            val distanceRequest = healthConnectClient.readRecords(
-                ReadRecordsRequest(
-                    recordType = DistanceRecord::class,
-                    timeRangeFilter = TimeRangeFilter.between(
-                        record.startTime,
-                        record.endTime,
-                    ),
-                ),
-            )
             var totalDistance = 0.0
-            for (distanceRec in distanceRequest.records) {
-                totalDistance += distanceRec.distance.inMeters
+            try {
+                val distanceRequest = healthConnectClient.readRecords(
+                    ReadRecordsRequest(
+                        recordType = DistanceRecord::class,
+                        timeRangeFilter = TimeRangeFilter.between(
+                            record.startTime,
+                            record.endTime,
+                        ),
+                    ),
+                )
+                for (distanceRec in distanceRequest.records) {
+                    totalDistance += distanceRec.distance.inMeters
+                }
+            } catch (e: Exception) {
+                Log.w(
+                    "FLUTTER_HEALTH::WARNING",
+                    "Unable to read distance data for workout ${record.metadata.id}: ${e.message}"
+                )
             }
 
-            // Get energy burned data
-            val energyBurnedRequest = healthConnectClient.readRecords(
-                ReadRecordsRequest(
-                    recordType = TotalCaloriesBurnedRecord::class,
-                    timeRangeFilter = TimeRangeFilter.between(
-                        record.startTime,
-                        record.endTime,
-                    ),
-                ),
-            )
             var totalEnergyBurned = 0.0
-            for (energyBurnedRec in energyBurnedRequest.records) {
-                totalEnergyBurned += energyBurnedRec.energy.inKilocalories
+            try {
+                val energyBurnedRequest = healthConnectClient.readRecords(
+                    ReadRecordsRequest(
+                        recordType = TotalCaloriesBurnedRecord::class,
+                        timeRangeFilter = TimeRangeFilter.between(
+                            record.startTime,
+                            record.endTime,
+                        ),
+                    ),
+                )
+                for (energyBurnedRec in energyBurnedRequest.records) {
+                    totalEnergyBurned += energyBurnedRec.energy.inKilocalories
+                }
+            } catch (e: Exception) {
+                Log.w(
+                    "FLUTTER_HEALTH::WARNING",
+                    "Unable to read energy burned data for workout ${record.metadata.id}: ${e.message}"
+                )
             }
 
-            // Get steps data
-            val stepRequest = healthConnectClient.readRecords(
-                ReadRecordsRequest(
-                    recordType = StepsRecord::class,
-                    timeRangeFilter = TimeRangeFilter.between(
-                        record.startTime,
-                        record.endTime
-                    ),
-                ),
-            )
             var totalSteps = 0.0
-            for (stepRec in stepRequest.records) {
-                totalSteps += stepRec.count
+            try {
+                val stepRequest = healthConnectClient.readRecords(
+                    ReadRecordsRequest(
+                        recordType = StepsRecord::class,
+                        timeRangeFilter = TimeRangeFilter.between(
+                            record.startTime,
+                            record.endTime
+                        ),
+                    ),
+                )
+                for (stepRec in stepRequest.records) {
+                    totalSteps += stepRec.count
+                }
+            } catch (e: Exception) {
+                Log.w(
+                    "FLUTTER_HEALTH::WARNING",
+                    "Unable to read steps data for workout ${record.metadata.id}: ${e.message}"
+                )
             }
 
             // Add final datapoint


### PR DESCRIPTION
## Context

Android’s Health Connect enforces a minimum scope policy, where apps must request only the permissions strictly required for their user-facing features.
Currently, reading workout sessions in this plugin implicitly requires Distance and Steps permissions, even when apps only need calories or basic exercise metadata.

This causes Play Store rejections for apps that do not expose distance or step data in their UI, as requesting these permissions cannot be justified under the policy.

---

## What’s changed

- Wrapped `DistanceRecord` reads in `try/catch` blocks
- Wrapped `StepsRecord` reads in `try/catch` blocks
- Allowed workout sessions to be processed even when optional metrics are unavailable
- Ensured `TotalCaloriesBurnedRecord` continues to be read independently
- Logged warnings instead of throwing errors when distance or steps data cannot be accessed

---

## Notes

This approach ensures the plugin works correctly across all permission scenarios, whether apps request a minimal or extended Health Connect permission set.

The warning logs provide clear signals during debugging, indicating which optional permissions are required for missing workout properties, without breaking the overall data retrieval flow.