### PR TITLE
Implement deduplication for health data records for workout

### DIFF
--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
@@ -614,7 +614,7 @@ class HealthDataReader(
 				.map { entry -> entry.value.maxByOrNull { it.distance.inMeters } ?: entry.value.first() }
 
 			// Group distance records by packageName and sum for each package
-			val distanceByPackage = uniqueDistanceRecords
+			val distanceByPackage = distanceRequest.records
 				.groupBy { it.metadata.dataOrigin.packageName }
 				.mapValues { entry ->
 					entry.value.sumOf { it.distance.inMeters }
@@ -643,12 +643,7 @@ class HealthDataReader(
 				.groupBy { Pair(it.startTime.toEpochMilli(), it.endTime.toEpochMilli()) }
 				.map { entry -> entry.value.maxByOrNull { it.energy.inKilocalories } ?: entry.value.first() }
 
-			val fitbitEnergyBurnedRecords = uniqueEnergyBurnedRecords.filter { it.metadata.dataOrigin.packageName == fitbitPackageName }
-				.sumOf { it.energy.inKilocalories }
-			val otherEnergyBurnedRecord = uniqueEnergyBurnedRecords.filter { it.metadata.dataOrigin .packageName != fitbitPackageName }
-				.sumOf { it.energy.inKilocalories}
-
-			val totalEnergyBurned = fitbitEnergyBurnedRecords + otherEnergyBurnedRecord
+			val totalEnergyBurned = energyBurnedRequest.records.sumOf { it.energy.inKilocalories }
 
             // Get steps data
             val stepRequest = healthConnectClient.readRecords(
@@ -667,7 +662,7 @@ class HealthDataReader(
 				.map { entry -> entry.value.maxByOrNull { it.count } ?: entry.value.first() }
 
 			// Group distance records by packageName and sum for each package
-			val stepsByPackage = uniqueStepRecords
+			val stepsByPackage = stepRequest.records
 				.groupBy { it.metadata.dataOrigin.packageName }
 				.mapValues { entry ->
 					entry.value.sumOf { it.count }


### PR DESCRIPTION
### Summary ###
Added deduplication for distance, energy burned, and steps records based on start and end times of the workout session, keeping the highest values.

### Context ### 
On Android, when I compare the workout data being returned by the package (`distance`, `steps` and `calories`) and the data in Fitbit or Health apps, the difference is huge (almost double the amount of data being returned by the Google health Apps).
When I fetch now individual health data types for the workout period (for `DISTANCE`, `TOTAL_CALORIES_BURNED` and `STEPS`), passing the data through  `Health().removeDuplicates(healthData)` function, the data is now accurate.

### Problem ###
The issue was how the package is calculating the workout records without removing duplicates, the same way the dart code provides that option.

### Solution ###
I added the deduplication functionality by checking only the `date_from` and `date_to` values and making sure that we don't have other records of the same time range. I am keeping the data with the highest `value` value as more often, it is the most accurate.