### PR TITLE
fix(android): map BIKING_STATIONARY for Health Connect workouts

### DIFF
--- a/android/src/main/kotlin/cachet/plugins/health/HealthConstants.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthConstants.kt
@@ -191,6 +191,7 @@ object HealthConstants {
         "BASEBALL" to ExerciseSessionRecord.EXERCISE_TYPE_BASEBALL,
         "BASKETBALL" to ExerciseSessionRecord.EXERCISE_TYPE_BASKETBALL,
         "BIKING" to ExerciseSessionRecord.EXERCISE_TYPE_BIKING,
+        "BIKING_STATIONARY" to ExerciseSessionRecord.EXERCISE_TYPE_BIKING_STATIONARY,
         "BOXING" to ExerciseSessionRecord.EXERCISE_TYPE_BOXING,
         "CALISTHENICS" to ExerciseSessionRecord.EXERCISE_TYPE_CALISTHENICS,
         "CARDIO_DANCE" to ExerciseSessionRecord.EXERCISE_TYPE_DANCING,


### PR DESCRIPTION
## Summary
  Fixes Android Health Connect workout writing for `BIKING_STATIONARY`.

  `HealthWorkoutActivityType.BIKING_STATIONARY` is exposed in Dart and marked Android-supported,
  but native write validation failed with:
  `[Health Connect] Workout type not supported`

  ## Root cause
  Android workout writes validate activity type strings against `HealthConstants.workoutTypeMap`.
  `BIKING_STATIONARY` was missing from that map.

  ## Change
  Added one mapping in `android/src/main/kotlin/cachet/plugins/health/HealthConstants.kt`:

  - `BIKING_STATIONARY -> ExerciseSessionRecord.EXERCISE_TYPE_BIKING_STATIONARY`

  ## Notes
  Other candidate mappings were intentionally not included because this plugin targets an older
  Health Connect version where those constants are not available.

  ## Verification
  - Ran `flutter analyze`.
  - No new analyzer errors from this change (only existing info-level lints in example/test files).