### PR TITLE
Bugfix: Adds `device_model` to iOS Dicts and Android maps

### DIFF
--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataChanges.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataChanges.kt
@@ -200,6 +200,7 @@ class HealthDataChanges(
             "date_to" to record.endTime.toEpochMilli(),
             "source_id" to "",
             "source_name" to record.metadata.dataOrigin.packageName,
+            "device_model" to record.metadata.device?.model,
             "recording_method" to record.metadata.recordingMethod,
         )
     }

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataConverter.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataConverter.kt
@@ -187,7 +187,8 @@ class HealthDataConverter {
         "uuid" to metadata.id,
         "source_id" to "",
         "source_name" to metadata.dataOrigin.packageName,
-        "recording_method" to metadata.recordingMethod
+        "recording_method" to metadata.recordingMethod,
+        "device_model" to metadata.device?.model
     )
 
     /**
@@ -283,6 +284,7 @@ class HealthDataConverter {
                 "date_to" to stage.endTime.toEpochMilli(),
                 "source_id" to "",
                 "source_name" to metadata.dataOrigin.packageName,
+                "device_model" to metadata.device?.model,
             )
         )
     }

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
@@ -367,6 +367,7 @@ class HealthDataReader(
             "date_to" to endTimestamp,
             "source_id" to session.metadata.dataOrigin.packageName,
             "source_name" to session.metadata.dataOrigin.packageName,
+            "device_model" to session.metadata.device?.model,
             "recording_method" to session.metadata.recordingMethod,
             "metadata" to metadata,
         )
@@ -389,6 +390,7 @@ class HealthDataReader(
             "date_to" to session.endTime.toEpochMilli(),
             "source_id" to session.metadata.dataOrigin.packageName,
             "source_name" to session.metadata.dataOrigin.packageName,
+            "device_model" to session.metadata.device?.model,
             "recording_method" to session.metadata.recordingMethod,
             "metadata" to metadata,
         )
@@ -660,6 +662,7 @@ class HealthDataReader(
                     "date_to" to record.endTime.toEpochMilli(),
                     "source_id" to "",
                     "source_name" to record.metadata.dataOrigin.packageName,
+                    "device_model" to record.metadata.device?.model,
                 ),
             )
         }

--- a/ios/Classes/HealthDataReader.swift
+++ b/ios/Classes/HealthDataReader.swift
@@ -190,6 +190,7 @@ class HealthDataReader {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
+                        "device_model": sample.sourceRevision.productType,
                         "recording_method":
                             (sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                             ? HealthConstants.RecordingMethod.manual.rawValue
@@ -238,6 +239,7 @@ class HealthDataReader {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
+                        "device_model": sample.sourceRevision.productType,
                         "recording_method":
                             (sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                             ? HealthConstants.RecordingMethod.manual.rawValue
@@ -265,6 +267,7 @@ class HealthDataReader {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
+                        "device_model": sample.sourceRevision.productType,
                         "recording_method":
                             (sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                             ? HealthConstants.RecordingMethod.manual.rawValue
@@ -308,6 +311,7 @@ class HealthDataReader {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
+                        "device_model": sample.sourceRevision.productType,
                     ]
                 }
                 DispatchQueue.main.async {
@@ -328,6 +332,7 @@ class HealthDataReader {
                             "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                             "source_id": sample.sourceRevision.source.bundleIdentifier,
                             "source_name": sample.sourceRevision.source.name,
+                            "device_model": sample.sourceRevision.productType,
                             "recording_method":
                                 (sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                                 ? HealthConstants.RecordingMethod.manual.rawValue
@@ -479,6 +484,7 @@ class HealthDataReader {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
+                        "device_model": sample.sourceRevision.productType,
                         "recording_method":
                             (sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                             ? HealthConstants.RecordingMethod.manual.rawValue
@@ -527,6 +533,7 @@ class HealthDataReader {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
+                        "device_model": sample.sourceRevision.productType,
                         "recording_method":
                             (sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                             ? HealthConstants.RecordingMethod.manual.rawValue
@@ -554,6 +561,7 @@ class HealthDataReader {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
+                        "device_model": sample.sourceRevision.productType,
                         "recording_method":
                             (sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                             ? HealthConstants.RecordingMethod.manual.rawValue
@@ -597,6 +605,7 @@ class HealthDataReader {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
+                        "device_model": sample.sourceRevision.productType,
                     ]
                 }
                 DispatchQueue.main.async {
@@ -617,6 +626,7 @@ class HealthDataReader {
                             "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                             "source_id": sample.sourceRevision.source.bundleIdentifier,
                             "source_name": sample.sourceRevision.source.name,
+                            "device_model": sample.sourceRevision.productType,
                             "recording_method":
                                 (sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                                 ? HealthConstants.RecordingMethod.manual.rawValue
@@ -1011,6 +1021,7 @@ class HealthDataReader {
             "date_to": endTimestamp,
             "source_id": route.sourceRevision.source.bundleIdentifier,
             "source_name": route.sourceRevision.source.name,
+            "device_model": route.sourceRevision.productType,
             "recording_method":
                 (route.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                 ? HealthConstants.RecordingMethod.manual.rawValue
@@ -1111,6 +1122,7 @@ class HealthDataReader {
                         "date_to": Int(ecg.endDate.timeIntervalSince1970 * 1000),
                         "source_id": ecg.sourceRevision.source.bundleIdentifier,
                         "source_name": ecg.sourceRevision.source.name,
+                        "device_model": ecg.sourceRevision.productType,
                     ]
                     lock.lock()
                     dictionaries.append(dict)

--- a/ios/Classes/HealthDataReader.swift
+++ b/ios/Classes/HealthDataReader.swift
@@ -267,7 +267,7 @@ class HealthDataReader {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
-                        "device_model": sample.sourceRevision.productType,
+                        "device_model": HealthUtilities.resolveWorkoutDeviceModel(sample),
                         "recording_method":
                             (sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                             ? HealthConstants.RecordingMethod.manual.rawValue
@@ -561,7 +561,7 @@ class HealthDataReader {
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
                         "source_name": sample.sourceRevision.source.name,
-                        "device_model": sample.sourceRevision.productType,
+                        "device_model": HealthUtilities.resolveWorkoutDeviceModel(sample),
                         "recording_method":
                             (sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                             ? HealthConstants.RecordingMethod.manual.rawValue

--- a/ios/Classes/HealthUtilities.swift
+++ b/ios/Classes/HealthUtilities.swift
@@ -2,6 +2,46 @@ import HealthKit
 
 /// Utilities class containing helper methods for data manipulation
 class HealthUtilities {
+    /// Resolve a best-effort device identifier for a workout's *recording* device.
+    ///
+    /// HealthKit exposes device information from several places, and which one
+    /// is populated depends on which app wrote the workout:
+    ///
+    /// 1. `sourceRevision.productType` is the Apple hardware identifier of the
+    ///    device running the source app (e.g. `"Watch6,1"`, `"iPhone14,2"`).
+    ///    For Apple-native workouts this correctly distinguishes Apple Watch
+    ///    from iPhone. For third-party apps (Garmin, Strava, etc.) it is
+    ///    always the iPhone model running the companion app, which is not the
+    ///    actual recording device.
+    /// 2. `HKSample.device.name` is set by the writing app and describes the
+    ///    actual recording hardware. Third-party apps frequently populate this
+    ///    with the friendly device name (e.g. `"Garmin fēnix 7"`).
+    /// 3. `HKMetadataKeyDeviceName` is a standard metadata key that some apps
+    ///    use instead of `HKSample.device`.
+    ///
+    /// Strategy: prefer `productType` for Apple-native workouts; for everything
+    /// else fall back to the device name reported by the writing app, then to
+    /// metadata, and finally to `productType` as a last resort.
+    static func resolveWorkoutDeviceModel(_ workout: HKWorkout) -> String? {
+        let bundleId = workout.sourceRevision.source.bundleIdentifier.lowercased()
+        let isAppleSource = bundleId.hasPrefix("com.apple.")
+
+        if isAppleSource, let productType = workout.sourceRevision.productType {
+            return productType
+        }
+
+        if let deviceName = workout.device?.name, !deviceName.isEmpty {
+            return deviceName
+        }
+
+        if let metadataDeviceName = workout.metadata?[HKMetadataKeyDeviceName] as? String,
+           !metadataDeviceName.isEmpty {
+            return metadataDeviceName
+        }
+
+        return workout.sourceRevision.productType
+    }
+
     /// Sanitize metadata to make it Flutter-friendly
     /// - Parameter metadata: The metadata dictionary to sanitize
     /// - Returns: A dictionary with sanitized values


### PR DESCRIPTION
*Duplicate of #472 in case Pull Requests are supposed to be sent to `main` rather than `dev` branch:

Root cause: The 13.0.x refactoring split the native code into separate reader/writer/converter classes but omitted the `"device_model"` key from every dictionary sent back to Flutter. The Dart side at health_data_point.dart reads `dataPoint["device_model"]`, which always returned `null` because the native layer never included it.

---

Fixes Issue #1 

---

Adds support for including the device model information in health data records on both Android and iOS platforms. The device model is now added to all relevant health data payloads.

**Device Model Support in Health Data Records:**

* Android: Added `"device_model"` field (from `metadata.device?.model`) to all relevant health data maps in `HealthDataReader`, `HealthDataConverter`, and `HealthDataChanges` to ensure the device model is included in exported records. [[1]](diffhunk://#diff-e19d366033a576bea836f4f48d1ea65afa799bb88103ba1d16fdbbbe07373e02R370) [[2]](diffhunk://#diff-e19d366033a576bea836f4f48d1ea65afa799bb88103ba1d16fdbbbe07373e02R393) [[3]](diffhunk://#diff-e19d366033a576bea836f4f48d1ea65afa799bb88103ba1d16fdbbbe07373e02R665) [[4]](diffhunk://#diff-3a4c8c8a6b373f2c40caf5bb0f91ffb1f34374286d89f5ad2529c8044111fd62L190-R191) [[5]](diffhunk://#diff-3a4c8c8a6b373f2c40caf5bb0f91ffb1f34374286d89f5ad2529c8044111fd62R287) [[6]](diffhunk://#diff-49463e377b1fb217bdfcaaf63d0653e8341446011938e23d4a82435d322acd5eR203)
* iOS: Added `"device_model"` field (from `sample.sourceRevision.productType` or equivalent) to all health data dictionaries in `HealthDataReader.swift`, ensuring device model is consistently included across all sample types. [[1]](diffhunk://#diff-726b04a572ca2e598a86519a1157420f9e203f7079b81d8eef08d4543ae929afR193) [[2]](diffhunk://#diff-726b04a572ca2e598a86519a1157420f9e203f7079b81d8eef08d4543ae929afR242) [[3]](diffhunk://#diff-726b04a572ca2e598a86519a1157420f9e203f7079b81d8eef08d4543ae929afR270) [[4]](diffhunk://#diff-726b04a572ca2e598a86519a1157420f9e203f7079b81d8eef08d4543ae929afR314) [[5]](diffhunk://#diff-726b04a572ca2e598a86519a1157420f9e203f7079b81d8eef08d4543ae929afR335) [[6]](diffhunk://#diff-726b04a572ca2e598a86519a1157420f9e203f7079b81d8eef08d4543ae929afR487) [[7]](diffhunk://#diff-726b04a572ca2e598a86519a1157420f9e203f7079b81d8eef08d4543ae929afR536) [[8]](diffhunk://#diff-726b04a572ca2e598a86519a1157420f9e203f7079b81d8eef08d4543ae929afR564) [[9]](diffhunk://#diff-726b04a572ca2e598a86519a1157420f9e203f7079b81d8eef08d4543ae929afR608) [[10]](diffhunk://#diff-726b04a572ca2e598a86519a1157420f9e203f7079b81d8eef08d4543ae929afR629) [[11]](diffhunk://#diff-726b04a572ca2e598a86519a1157420f9e203f7079b81d8eef08d4543ae929afR1024) [[12]](diffhunk://#diff-726b04a572ca2e598a86519a1157420f9e203f7079b81d8eef08d4543ae929afR1125)