### PR TITLE
fix(iOS): remove TOTAL_CALORIES_BURNED from dataTypeKeysIOS — causes SIGABRT crash

### DIFF
--- a/lib/src/heath_data_types.dart
+++ b/lib/src/heath_data_types.dart
@@ -224,7 +224,6 @@ const List<HealthDataType> dataTypeKeysIOS = [
   HealthDataType.WATER_TEMPERATURE,
   HealthDataType.UNDERWATER_DEPTH,
   HealthDataType.UV_INDEX,
-  HealthDataType.TOTAL_CALORIES_BURNED,
   HealthDataType.SLEEP_WRIST_TEMPERATURE,
 ];
 


### PR DESCRIPTION
## Summary

Removes `TOTAL_CALORIES_BURNED` from `dataTypeKeysIOS` — it has no entry in the native iOS `dataTypesDict`, causing `requestAuthorization` to pass `nil` to `HKHealthStore._validateAuthorizationRequestWithShareTypes:readTypes:`, which throws an `NSException` (SIGABRT). The crash is not catchable in Dart.

iOS HealthKit has no single equivalent — it has `activeEnergyBurned` + `basalEnergyBurned` separately. This type is Android-only (Health Connect's `TotalCaloriesBurnedRecord`).

## Test

```dart
// Before fix: SIGABRT crash
// After fix: type correctly excluded from iOS platform list
await health.requestAuthorization([HealthDataType.TOTAL_CALORIES_BURNED]);
```

Verified on iOS simulator (iOS 26.4) — crash confirmed before fix, type correctly filtered after.

Fixes #483