### PR TITLE
feat: idempotent writeWorkoutData + accurate authorization helpers

### DIFF
--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataOperations.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataOperations.kt
@@ -65,6 +65,51 @@ class HealthDataOperations(
     }
 
     /**
+     * Returns the accurate WRITE authorisation status for every supplied
+     * type, combined via worst-case aggregation and encoded as one of the
+     * wire strings consumed by Dart's `HealthPermissionStatus.fromWire`.
+     *
+     * Health Connect only exposes a granted/not-granted boolean per
+     * permission, so Android can only return `'granted'` or `'denied'`
+     * (never `'notDetermined'`). Callers that need the three-valued status
+     * should treat the Dart-side `notDetermined` branch as iOS-specific.
+     *
+     * @param call Method call containing 'types' (list of data type strings)
+     * @param result Flutter result callback returning the wire string
+     */
+    fun accurateAuthorizationStatus(call: MethodCall, result: Result) {
+        val args = call.arguments as HashMap<*, *>
+        val types = (args["types"] as? ArrayList<*>)?.filterIsInstance<String>()
+            ?: run {
+                result.success("notDetermined")
+                return
+            }
+        if (types.isEmpty()) {
+            result.success("notDetermined")
+            return
+        }
+
+        // Every requested type is probed for WRITE access (index 1 == WRITE
+        // in the Dart HealthDataAccess enum).
+        val permList = preparePermissionsListInternal(
+            types,
+            List(types.size) { 1 },
+        )
+        if (permList == null) {
+            result.success("denied")
+            return
+        }
+
+        scope.launch {
+            val granted = healthConnectClient
+                .permissionController
+                .getGrantedPermissions()
+                .containsAll(permList)
+            result.success(if (granted) "granted" else "denied")
+        }
+    }
+
+    /**
      * Prepares a list of Health Connect permission strings for authorization requests. Converts
      * Flutter data types and permission levels into Health Connect permission format.
      *

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataOperations.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataOperations.kt
@@ -135,10 +135,15 @@ class HealthDataOperations(
      */
     fun revokePermissions(call: MethodCall, result: Result) {
         scope.launch {
-            Log.i("FLUTTER_HEALTH", "Revoking all Health Connect permissions")
-            healthConnectClient.permissionController.revokeAllPermissions()
+            try {
+                Log.i("FLUTTER_HEALTH", "Revoking all Health Connect permissions")
+                healthConnectClient.permissionController.revokeAllPermissions()
+                result.success(true)
+            } catch (e: Exception) {
+                Log.e("FLUTTER_HEALTH::ERROR", "Error revoking permissions: ${e.message}")
+                result.success(false)
+            }
         }
-        result.success(true)
     }
 
     /**

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataWriter.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataWriter.kt
@@ -362,9 +362,33 @@ class HealthDataWriter(
                 )
                 Log.w("FLUTTER_HEALTH::ERROR", e.message ?: "unknown error")
                 Log.w("FLUTTER_HEALTH::ERROR", e.stackTrace.toString())
-                result.success(false)
+                // Surface a typed FlutterError so Dart callers can classify
+                // failures (permission / platform unavailability / other)
+                // rather than collapsing everything into `success == false`.
+                result.error(
+                    workoutWriteErrorCode(e),
+                    e.message ?: e.javaClass.simpleName,
+                    mapOf(
+                        "exceptionClass" to e.javaClass.name,
+                    ),
+                )
             }
         }
+    }
+
+    /**
+     * Maps a workout-write exception to a stable `code` string that Dart
+     * callers switch on. `SECURITY_EXCEPTION` is the single permission
+     * signal emitted by Health Connect writes; IO / remote errors surface
+     * under their own codes so callers can distinguish transient failures
+     * from platform-unavailability. Anything unknown falls through to
+     * `WRITE_ERROR` so the signal is preserved.
+     */
+    private fun workoutWriteErrorCode(e: Exception): String = when (e) {
+        is SecurityException -> "SECURITY_EXCEPTION"
+        is java.io.IOException -> "IO_EXCEPTION"
+        is android.os.RemoteException -> "REMOTE_EXCEPTION"
+        else -> "WRITE_ERROR"
     }
 
     /**

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataWriter.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataWriter.kt
@@ -9,6 +9,7 @@ import androidx.health.connect.client.units.*
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel.Result
 import java.time.Instant
+import java.time.ZoneOffset
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -23,6 +24,22 @@ class HealthDataWriter(
 ) {
     private val workoutRouteBuilders =
         mutableMapOf<String, MutableList<ExerciseRoute.Location>>()
+
+    // Returns null for out-of-range offsets (|offset| > 18h) instead of
+    // letting `ZoneOffset.ofTotalSeconds` throw DateTimeException. Callers
+    // treat "no offset" as the safe fallback rather than failing the whole
+    // workout write for a bad offset value.
+    private fun safeZoneOffset(totalSeconds: Int): ZoneOffset? {
+        return try {
+            ZoneOffset.ofTotalSeconds(totalSeconds)
+        } catch (e: java.time.DateTimeException) {
+            Log.w(
+                "FLUTTER_HEALTH::WARN",
+                "[Health Connect] Ignoring out-of-range zone offset: ${totalSeconds}s",
+            )
+            null
+        }
+    }
 
     // Maps incoming recordingMethod int -> Metadata factory method.
     // 0: unknown, 1: manual, 2: auto, 3: active (default unknown for others)
@@ -232,7 +249,39 @@ class HealthDataWriter(
         val totalDistance = call.argument<Int>("totalDistance")
         val recordingMethod = call.argument<Int>("recordingMethod")!!
         val deviceType: Int? = call.argument<Int>("deviceType")
-        val workoutMetadata = buildMetadata(recordingMethod = recordingMethod, deviceType = deviceType)
+        val clientRecordId: String? = call.argument<String>("clientRecordId")
+        val clientRecordVersion: Double? = call.argument<Double>("clientRecordVersion")
+        // `ZoneOffset.ofTotalSeconds` throws `DateTimeException` when the
+        // magnitude exceeds UTC±18h. Catch it up-front so an out-of-range
+        // caller value never surfaces as an uncaught exception.
+        val startZoneOffset: ZoneOffset? =
+            call.argument<Int>("startZoneOffsetSeconds")?.let { safeZoneOffset(it) }
+        val endZoneOffset: ZoneOffset? =
+            call.argument<Int>("endZoneOffsetSeconds")?.let { safeZoneOffset(it) }
+        val useActiveEnergy: Boolean = call.argument<Boolean>("useActiveEnergy") ?: false
+
+        // Metadata for the session itself — carries the idempotency keys.
+        val workoutMetadata = buildMetadata(
+            recordingMethod = recordingMethod,
+            clientRecordId = clientRecordId,
+            clientRecordVersion = clientRecordVersion?.toLong(),
+            deviceType = deviceType,
+        )
+        // Linked records (distance / calories) need distinct clientRecordIds
+        // or Health Connect rejects the batch as duplicate upserts. Derive
+        // stable suffixes so re-writes stay idempotent.
+        val distanceMetadata = buildMetadata(
+            recordingMethod = recordingMethod,
+            clientRecordId = clientRecordId?.let { "$it:distance" },
+            clientRecordVersion = clientRecordVersion?.toLong(),
+            deviceType = deviceType,
+        )
+        val energyMetadata = buildMetadata(
+            recordingMethod = recordingMethod,
+            clientRecordId = clientRecordId?.let { "$it:calories" },
+            clientRecordVersion = clientRecordVersion?.toLong(),
+            deviceType = deviceType,
+        )
 
         if (!HealthConstants.workoutTypeMap.containsKey(type)) {
             result.success(false)
@@ -251,9 +300,9 @@ class HealthDataWriter(
                 list.add(
                         ExerciseSessionRecord(
                                 startTime = startTime,
-                                startZoneOffset = null,
+                                startZoneOffset = startZoneOffset,
                                 endTime = endTime,
-                                endZoneOffset = null,
+                                endZoneOffset = endZoneOffset,
                                 exerciseType = workoutType,
                                 title = title,
                                 metadata = workoutMetadata,
@@ -265,26 +314,41 @@ class HealthDataWriter(
                     list.add(
                             DistanceRecord(
                                     startTime = startTime,
-                                    startZoneOffset = null,
+                                    startZoneOffset = startZoneOffset,
                                     endTime = endTime,
-                                    endZoneOffset = null,
+                                    endZoneOffset = endZoneOffset,
                                     distance = Length.meters(totalDistance.toDouble()),
-                                    metadata = workoutMetadata,
+                                    metadata = distanceMetadata,
                             ),
                     )
                 }
 
-                // Add energy burned record if provided
+                // Add energy burned record if provided. Default stays on the
+                // upstream TotalCaloriesBurnedRecord; callers that measure
+                // only the workout's active contribution (excluding BMR) can
+                // opt into ActiveCaloriesBurnedRecord via [useActiveEnergy].
                 if (totalEnergyBurned != null) {
+                    val energy = Energy.kilocalories(totalEnergyBurned.toDouble())
                     list.add(
-                            TotalCaloriesBurnedRecord(
-                                    startTime = startTime,
-                                    startZoneOffset = null,
-                                    endTime = endTime,
-                                    endZoneOffset = null,
-                                    energy = Energy.kilocalories(totalEnergyBurned.toDouble()),
-                                    metadata = workoutMetadata,
-                            ),
+                            if (useActiveEnergy) {
+                                ActiveCaloriesBurnedRecord(
+                                        startTime = startTime,
+                                        startZoneOffset = startZoneOffset,
+                                        endTime = endTime,
+                                        endZoneOffset = endZoneOffset,
+                                        energy = energy,
+                                        metadata = energyMetadata,
+                                )
+                            } else {
+                                TotalCaloriesBurnedRecord(
+                                        startTime = startTime,
+                                        startZoneOffset = startZoneOffset,
+                                        endTime = endTime,
+                                        endZoneOffset = endZoneOffset,
+                                        energy = energy,
+                                        metadata = energyMetadata,
+                                )
+                            },
                     )
                 }
 

--- a/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -131,6 +131,9 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
 
             // Permissions
             "hasPermissions" -> dataOperations.hasPermissions(call, result)
+            "accurateAuthorizationStatus" ->
+                    dataOperations.accurateAuthorizationStatus(call, result)
+            "isHealthConnectPackageInstalled" -> isHealthConnectPackageInstalled(result)
             "requestAuthorization" -> requestAuthorization(call, result)
             "revokePermissions" -> dataOperations.revokePermissions(call, result)
 
@@ -260,6 +263,30 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
      * @param call Method call from Flutter (unused)
      * @param result Flutter result callback
      */
+    /**
+     * Returns true when the Google Health Connect provider package is
+     * installed on-device. Lets callers distinguish "not installed" from
+     * "installed but needs update" — a distinction [getHealthConnectSdkStatus]
+     * collapses into a single provider-update-required value.
+     */
+    private fun isHealthConnectPackageInstalled(result: Result) {
+        val ctx = context
+        if (ctx == null) {
+            result.success(false)
+            return
+        }
+        val installed = try {
+            ctx.packageManager.getPackageInfo(
+                "com.google.android.apps.healthdata",
+                0,
+            )
+            true
+        } catch (_: android.content.pm.PackageManager.NameNotFoundException) {
+            false
+        }
+        result.success(installed)
+    }
+
     private fun installHealthConnect(call: MethodCall, result: Result) {
         val uriString =
                 "market://details?id=com.google.android.apps.healthdata&url=healthconnect%3A%2F%2Fonboarding"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -58,6 +58,8 @@ enum AppState {
   PERMISSIONS_NOT_REVOKED,
   CHANGES_READY,
   CHANGES_NOT_READY,
+  IDEMPOTENCY_DEMO_RUNNING,
+  IDEMPOTENCY_DEMO_RESULT,
 }
 
 class HealthAppState extends State<HealthApp> {
@@ -728,6 +730,91 @@ class HealthAppState extends State<HealthApp> {
     });
   }
 
+  /// Demonstrates the idempotent-write guarantees the fork adds to
+  /// `writeWorkoutData`. Writes the same workout twice with the same
+  /// `syncIdentifier` (iOS) and `clientRecordId` (Android), then queries
+  /// back and reports the count — expected to be exactly one record
+  /// regardless of how many times the button is tapped in a day.
+  ///
+  /// Use this as a hand-operated smoke test before pinning the fork in a
+  /// downstream app, and link a screen recording of it in the upstream PR
+  /// description to show the new keys actually dedup on real devices.
+  Future<void> idempotencyDemo() async {
+    const demoTitle = 'Magic Idempotency Demo';
+    final now = DateTime.now();
+    final start = now.subtract(const Duration(minutes: 15));
+
+    // Day-bucketed ID — tapping the button 20 times today still collapses
+    // to a single record; tomorrow's tap produces a fresh one.
+    final sessionId =
+        'magic-demo-${now.year.toString().padLeft(4, '0')}-'
+        '${now.month.toString().padLeft(2, '0')}-'
+        '${now.day.toString().padLeft(2, '0')}';
+
+    setState(() {
+      _state = AppState.IDEMPOTENCY_DEMO_RUNNING;
+      _idempotencyMessage = 'Running idempotency demo ($sessionId)...';
+    });
+    debugPrint('[idempotencyDemo] sessionId=$sessionId start=$start end=$now');
+
+    Future<bool> writeOnce() => health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: start,
+          end: now,
+          title: demoTitle,
+          totalEnergyBurned: 150,
+          totalDistance: 1200,
+          recordingMethod: RecordingMethod.active,
+          syncIdentifier: sessionId,
+          syncVersion: 1,
+          clientRecordId: sessionId,
+          clientRecordVersion: 1,
+          startZoneOffset: now.timeZoneOffset,
+          endZoneOffset: now.timeZoneOffset,
+          useActiveEnergy: true,
+          iosExtraMetadata: const {
+            'fit.magic.demoMarker': 'idempotency',
+          },
+        );
+
+    String message;
+    try {
+      final first = await writeOnce();
+      debugPrint('[idempotencyDemo] first write returned $first');
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      final second = await writeOnce();
+      debugPrint('[idempotencyDemo] second write returned $second');
+
+      // Requery — this proves the dedup actually happened at the platform
+      // layer, not just that `writeWorkoutData` returned true twice.
+      final workouts = await health.getHealthDataFromTypes(
+        types: const [HealthDataType.WORKOUT],
+        startTime: start.subtract(const Duration(hours: 1)),
+        endTime: now.add(const Duration(hours: 1)),
+      );
+      final matching = workouts.where((point) {
+        final value = point.value;
+        if (value is! WorkoutHealthValue) return false;
+        return value.workoutActivityType == HealthWorkoutActivityType.RUNNING;
+      }).length;
+      debugPrint('[idempotencyDemo] matching RUNNING workouts: $matching');
+
+      message = 'Wrote 2× (first=$first, second=$second)\n'
+          'found $matching matching workout(s) → expected 1\n'
+          'sessionId: $sessionId\n'
+          'Now open Health Connect to eyeball.';
+    } catch (e, stack) {
+      debugPrint('[idempotencyDemo] FAILED: $e\n$stack');
+      message = 'Idempotency demo failed: $e';
+    }
+
+    if (!mounted) return;
+    setState(() {
+      _state = AppState.IDEMPOTENCY_DEMO_RESULT;
+      _idempotencyMessage = message;
+    });
+  }
+
   Future<bool> _ensureSkinTemperaturePermissions({
     required HealthDataAccess access,
   }) async {
@@ -1194,6 +1281,16 @@ class HealthAppState extends State<HealthApp> {
                           style: TextStyle(color: Colors.white),
                         ),
                       ),
+                      TextButton(
+                        onPressed: idempotencyDemo,
+                        style: const ButtonStyle(
+                          backgroundColor: WidgetStatePropertyAll(Colors.green),
+                        ),
+                        child: const Text(
+                          "Test Idempotency",
+                          style: TextStyle(color: Colors.white),
+                        ),
+                      ),
                       if (Platform.isIOS || Platform.isAndroid)
                         TextButton(
                           onPressed: writeWorkoutRoute,
@@ -1467,6 +1564,12 @@ class HealthAppState extends State<HealthApp> {
     'No status, click "Check Skin Temp Feature" to get the status.',
   );
 
+  String _idempotencyMessage = 'Tap "Test Idempotency" to run the demo.';
+  Widget get _contentIdempotencyDemo => Padding(
+        padding: const EdgeInsets.all(16),
+        child: Text(_idempotencyMessage),
+      );
+
   final Widget _dataAdded = const Text('Data points inserted successfully.');
 
   final Widget _dataDeleted = const Text('Data points deleted successfully.');
@@ -1559,6 +1662,8 @@ class HealthAppState extends State<HealthApp> {
     AppState.PERMISSIONS_NOT_REVOKED => _permissionsNotRevoked,
     AppState.CHANGES_READY => _contentChangesReady,
     AppState.CHANGES_NOT_READY => _contentChangesNotReady,
+    AppState.IDEMPOTENCY_DEMO_RUNNING => _contentIdempotencyDemo,
+    AppState.IDEMPOTENCY_DEMO_RESULT => _contentIdempotencyDemo,
   };
 
   Widget _detailedBottomSheet({HealthDataPoint? healthPoint}) {

--- a/ios/Classes/HealthDataOperations.swift
+++ b/ios/Classes/HealthDataOperations.swift
@@ -104,6 +104,71 @@ class HealthDataOperations {
         }
     }
 
+    /// Returns the accurate, per-type WRITE authorisation status combined
+    /// via worst-case aggregation.
+    ///
+    /// HealthKit's `authorizationStatus(for:)` returns one of:
+    ///   * `.notDetermined` — user has not yet chosen
+    ///   * `.sharingDenied` — user denied (or HK hides READ intent)
+    ///   * `.sharingAuthorized` — user granted write access
+    ///
+    /// Aggregation rules (any denied → denied; any notDetermined → nd;
+    /// otherwise granted) match the Dart-side [HealthPermissionStatus]
+    /// semantics.
+    func accurateAuthorizationStatus(call: FlutterMethodCall, result: @escaping FlutterResult) throws {
+        let arguments = call.arguments as? NSDictionary
+        guard var types = arguments?["types"] as? [String], !types.isEmpty
+        else {
+            throw PluginError(message: "Invalid Arguments - types missing or empty")
+        }
+
+        // Expand the NUTRITION composite to its underlying sample types so
+        // aggregation considers every HK type the plugin tracks for it.
+        if let nutritionIndex = types.firstIndex(of: HealthConstants.NUTRITION) {
+            types.remove(at: nutritionIndex)
+            types.append(contentsOf: nutritionList)
+        }
+
+        var sawNotDetermined = false
+
+        for type in types {
+            guard let sampleType = dataTypesDict[type] else {
+                // Unknown type → fail-closed as notDetermined.
+                sawNotDetermined = true
+                continue
+            }
+            let status = healthStore.authorizationStatus(for: sampleType)
+            switch status {
+            case .sharingDenied:
+                result("denied")
+                return
+            case .notDetermined:
+                sawNotDetermined = true
+            case .sharingAuthorized:
+                break
+            @unknown default:
+                sawNotDetermined = true
+            }
+
+            if let characteristicType = characteristicsTypesDict[type] {
+                let charStatus = healthStore.authorizationStatus(for: characteristicType)
+                switch charStatus {
+                case .sharingDenied:
+                    result("denied")
+                    return
+                case .notDetermined:
+                    sawNotDetermined = true
+                case .sharingAuthorized:
+                    break
+                @unknown default:
+                    sawNotDetermined = true
+                }
+            }
+        }
+
+        result(sawNotDetermined ? "notDetermined" : "granted")
+    }
+
     /// Request authorization for health data
     /// - Parameters:
     ///   - call: Flutter method call

--- a/ios/Classes/HealthDataWriter.swift
+++ b/ios/Classes/HealthDataWriter.swift
@@ -866,6 +866,26 @@ class HealthDataWriter {
         let dateFrom = HealthUtilities.dateFromMilliseconds(startTime.doubleValue)
         let dateTo = HealthUtilities.dateFromMilliseconds(endTime.doubleValue)
 
+        // Build optional metadata dict. Populated only when at least one
+        // key is provided so existing callers still get `metadata: nil`
+        // behaviour byte-for-byte.
+        //
+        // Merge order is load-bearing: extras first so the explicit sync
+        // identifier + version always wins over any colliding key a caller
+        // accidentally pulls in through `iosExtraMetadata`.
+        var metadata: [String: Any] = [:]
+        if let extra = arguments["iosExtraMetadata"] as? [String: Any] {
+            for (key, value) in extra {
+                metadata[key] = value
+            }
+        }
+        if let syncIdentifier = arguments["syncIdentifier"] as? String,
+           let syncVersion = arguments["syncVersion"] as? Int {
+            metadata[HKMetadataKeySyncIdentifier] = syncIdentifier
+            metadata[HKMetadataKeySyncVersion] = syncVersion
+        }
+        let workoutMetadata: [String: Any]? = metadata.isEmpty ? nil : metadata
+
         let workout = HKWorkout(
             activityType: activityTypeValue,
             start: dateFrom,
@@ -873,7 +893,7 @@ class HealthDataWriter {
             duration: dateTo.timeIntervalSince(dateFrom),
             totalEnergyBurned: totalEnergyBurned ?? nil,
             totalDistance: totalDistance ?? nil,
-            metadata: nil
+            metadata: workoutMetadata
         )
 
         healthStore.save(

--- a/ios/Classes/HealthDataWriter.swift
+++ b/ios/Classes/HealthDataWriter.swift
@@ -899,13 +899,73 @@ class HealthDataWriter {
         healthStore.save(
             workout,
             withCompletion: { success, error in
-                if let err = error {
-                    print("Error Saving Workout. Sample: \(err.localizedDescription)")
-                }
                 DispatchQueue.main.async {
-                    result(success)
+                    if let err = error as NSError? {
+                        // Surface HealthKit failures as typed FlutterErrors so
+                        // Dart callers can classify them (permission / platform
+                        // unavailability / other). `code` is the HKError.Code
+                        // enum raw value, optionally mapped to a readable name
+                        // for the common cases.
+                        let code = HealthDataWriter.workoutWriteErrorCode(for: err)
+                        result(
+                            FlutterError(
+                                code: code,
+                                message: err.localizedDescription,
+                                details: [
+                                    "domain": err.domain,
+                                    "nativeCode": err.code,
+                                ]
+                            )
+                        )
+                        return
+                    }
+                    // HealthKit convention: on success the completion block is
+                    // called with `success == true`. A `success == false` with
+                    // no `error` is unexpected; surface it as a structured
+                    // WRITE_UNKNOWN so callers don't lose the signal.
+                    if !success {
+                        result(
+                            FlutterError(
+                                code: "WRITE_UNKNOWN",
+                                message: "HealthStore.save returned false with no error",
+                                details: nil
+                            )
+                        )
+                        return
+                    }
+                    result(true)
                 }
             }
         )
+    }
+
+    /// Maps an `NSError` from `HKHealthStore.save` onto a stable string code
+    /// that Dart callers can switch on. The most common codes get readable
+    /// names; rare / future codes fall through to `HK_ERROR_<raw>` so we
+    /// never lose the signal. Only errors in `HKErrorDomain` get the
+    /// `HK_` prefix; other domains surface as `WRITE_ERROR` with the raw
+    /// code in `details`.
+    private static func workoutWriteErrorCode(for err: NSError) -> String {
+        guard err.domain == HKErrorDomain else {
+            return "WRITE_ERROR"
+        }
+        switch err.code {
+        case HKError.Code.errorHealthDataUnavailable.rawValue:
+            return "HK_DATA_UNAVAILABLE"
+        case HKError.Code.errorHealthDataRestricted.rawValue:
+            return "HK_DATA_RESTRICTED"
+        case HKError.Code.errorInvalidArgument.rawValue:
+            return "HK_INVALID_ARGUMENT"
+        case HKError.Code.errorAuthorizationDenied.rawValue:
+            return "HK_AUTHORIZATION_DENIED"
+        case HKError.Code.errorAuthorizationNotDetermined.rawValue:
+            return "HK_AUTHORIZATION_NOT_DETERMINED"
+        case HKError.Code.errorDatabaseInaccessible.rawValue:
+            return "HK_DATABASE_INACCESSIBLE"
+        case HKError.Code.errorUserCanceled.rawValue:
+            return "HK_USER_CANCELED"
+        default:
+            return "HK_ERROR_\(err.code)"
+        }
     }
 }

--- a/ios/Classes/SwiftHealthPlugin.swift
+++ b/ios/Classes/SwiftHealthPlugin.swift
@@ -163,6 +163,15 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
                                     details: nil))
             }
 
+        case "accurateAuthorizationStatus":
+            do {
+                try healthDataOperations.accurateAuthorizationStatus(call: call, result: result)
+            } catch {
+                result(FlutterError(code: "PERMISSION_ERROR",
+                                    message: "Error reading authorisation status: \(error.localizedDescription)",
+                                    details: nil))
+            }
+
         case "delete":
             do {
                 healthDataOperations.delete(call: call, result: result)

--- a/lib/src/health_plugin.dart
+++ b/lib/src/health_plugin.dart
@@ -132,6 +132,54 @@ class Health {
     });
   }
 
+  /// Returns the accurate, per-type WRITE authorisation status combining
+  /// every [HealthDataType] in [types] via worst-case aggregation.
+  ///
+  /// Aggregation rules:
+  ///   * any type is `denied` → [HealthPermissionStatus.denied]
+  ///   * any type is `notDetermined` (and none are `denied`) →
+  ///     [HealthPermissionStatus.notDetermined]
+  ///   * all types are granted → [HealthPermissionStatus.granted]
+  ///
+  /// This is the recommended check before attempting a write path: unlike
+  /// [hasPermissions] it reports the real per-type state and cannot return
+  /// `null` on iOS.
+  ///
+  /// Caveat: iOS intentionally does not expose READ authorisation state for
+  /// privacy reasons, so this method is only meaningful for write intent.
+  /// Android reuses the same Health Connect grant check as [hasPermissions].
+  Future<HealthPermissionStatus> accurateAuthorizationStatus({
+    required List<HealthDataType> types,
+  }) async {
+    if (types.isEmpty) {
+      throw ArgumentError('types must not be empty');
+    }
+    await _checkIfHealthConnectAvailableOnAndroid();
+    final wire = await _channel.invokeMethod<String>(
+      'accurateAuthorizationStatus',
+      {'types': types.map((type) => type.name).toList()},
+    );
+    return HealthPermissionStatus.fromWire(wire);
+  }
+
+  /// Returns `true` when the Google Health Connect provider package is
+  /// installed on the device.
+  ///
+  /// Distinguishes "Health Connect not installed" from "Health Connect
+  /// installed but needs an update" — a distinction [getHealthConnectSdkStatus]
+  /// collapses into a single
+  /// `HealthConnectSdkStatus.sdkUnavailableProviderUpdateRequired` value.
+  /// Use this in conjunction with [getHealthConnectSdkStatus] to route the
+  /// user either to an install prompt or an update prompt.
+  ///
+  /// On iOS this returns `true` unconditionally — there is no Health Connect
+  /// package to install.
+  Future<bool> isHealthConnectPackageInstalled() async {
+    if (Platform.isIOS) return true;
+    final installed = await _channel.invokeMethod<bool>('isHealthConnectPackageInstalled');
+    return installed == true;
+  }
+
   /// Revokes Google Health Connect permissions on Android of all types.
   ///
   /// NOTE: The app must be completely killed and restarted for the changes to take effect.

--- a/lib/src/health_plugin.dart
+++ b/lib/src/health_plugin.dart
@@ -1509,6 +1509,15 @@ class Health {
   ///  - [title] The title of the workout.
   ///    *ONLY FOR HEALTH CONNECT* Default value is the [activityType], e.g. "STRENGTH_TRAINING".
   ///  - [recordingMethod] The recording method of the data point, automatic by default (on iOS this can only be automatic or manual).
+  ///  - [syncIdentifier] *ONLY FOR IOS* Stable id written into `HKMetadataKeySyncIdentifier`. Re-writing a workout with the same [syncIdentifier] + [syncVersion] is a no-op (HealthKit upsert).
+  ///  - [syncVersion] *ONLY FOR IOS* Version paired with [syncIdentifier]. Must be non-null when [syncIdentifier] is non-null.
+  ///  - [clientRecordId] *ONLY FOR HEALTH CONNECT* Stable id used for upsert semantics via `Metadata.clientRecordId`.
+  ///  - [clientRecordVersion] *ONLY FOR HEALTH CONNECT* Version paired with [clientRecordId]. Same-or-lower version is a no-op.
+  ///  - [startZoneOffset] *ONLY FOR HEALTH CONNECT* Zone offset attached to both the workout session and linked records. Preserves historical local-day aggregation across timezone changes.
+  ///  - [endZoneOffset] *ONLY FOR HEALTH CONNECT* Zone offset at end of workout.
+  ///  - [deviceType] *ONLY FOR HEALTH CONNECT* Value from `androidx.health.connect.client.records.metadata.Device` type constants; required by Health Connect when [recordingMethod] is `active` or `automatic`.
+  ///  - [iosExtraMetadata] *ONLY FOR IOS* Arbitrary keys merged into the `HKWorkout` metadata dictionary (e.g. `HKMetadataKeyWorkoutBrandName`, app-owned keys for title/display).
+  ///  - [useActiveEnergy] *ONLY FOR HEALTH CONNECT* When true the calorie record is emitted as `ActiveCaloriesBurnedRecord` instead of `TotalCaloriesBurnedRecord`. Use this when [totalEnergyBurned] represents only the workout's contribution (excluding BMR).
   Future<bool> writeWorkoutData({
     required HealthWorkoutActivityType activityType,
     required DateTime start,
@@ -1519,10 +1528,31 @@ class Health {
     HealthDataUnit totalDistanceUnit = HealthDataUnit.METER,
     String? title,
     RecordingMethod recordingMethod = RecordingMethod.automatic,
+    String? syncIdentifier,
+    int? syncVersion,
+    String? clientRecordId,
+    double? clientRecordVersion,
+    Duration? startZoneOffset,
+    Duration? endZoneOffset,
+    int? deviceType,
+    Map<String, Object>? iosExtraMetadata,
+    bool useActiveEnergy = false,
   }) async {
     await _checkIfHealthConnectAvailableOnAndroid();
     if (Platform.isIOS && [RecordingMethod.active, RecordingMethod.unknown].contains(recordingMethod)) {
       throw ArgumentError("recordingMethod must be manual or automatic on iOS");
+    }
+    if (syncIdentifier != null && syncVersion == null) {
+      throw ArgumentError('syncVersion is required when syncIdentifier is provided');
+    }
+    if (syncVersion != null && syncIdentifier == null) {
+      throw ArgumentError('syncIdentifier is required when syncVersion is provided');
+    }
+    if (clientRecordId != null && clientRecordVersion == null) {
+      throw ArgumentError('clientRecordVersion is required when clientRecordId is provided');
+    }
+    if (clientRecordVersion != null && clientRecordId == null) {
+      throw ArgumentError('clientRecordId is required when clientRecordVersion is provided');
     }
 
     // Check that value is on the current Platform
@@ -1541,6 +1571,15 @@ class Health {
       'totalDistanceUnit': totalDistanceUnit.name,
       'title': title,
       'recordingMethod': recordingMethod.toInt(),
+      'syncIdentifier': syncIdentifier,
+      'syncVersion': syncVersion,
+      'clientRecordId': clientRecordId,
+      'clientRecordVersion': clientRecordVersion,
+      'startZoneOffsetSeconds': startZoneOffset?.inSeconds,
+      'endZoneOffsetSeconds': endZoneOffset?.inSeconds,
+      'deviceType': deviceType,
+      'iosExtraMetadata': iosExtraMetadata,
+      'useActiveEnergy': useActiveEnergy,
     };
     return await _channel.invokeMethod('writeWorkoutData', args) == true;
   }

--- a/lib/src/health_value_types.dart
+++ b/lib/src/health_value_types.dart
@@ -1112,6 +1112,42 @@ enum MenstrualFlow {
   }
 }
 
+/// Accurate, per-type authorisation status returned by
+/// [Health.accurateAuthorizationStatus].
+///
+/// Unlike [Health.hasPermissions] (which collapses iOS READ intent to `null`
+/// for privacy reasons and combines Android's per-type state into a single
+/// boolean), this enum tracks the three-valued status HealthKit and Health
+/// Connect actually expose for write intent.
+enum HealthPermissionStatus {
+  /// The user has not yet been asked (or the system has not yet recorded a
+  /// decision). Call [Health.requestAuthorization] to trigger the prompt.
+  notDetermined,
+
+  /// The user explicitly declined access, or the platform otherwise will not
+  /// grant it. Subsequent writes will fail until the user re-grants via
+  /// platform settings.
+  denied,
+
+  /// The requested access has been granted for every supplied type.
+  granted;
+
+  /// Parse a wire string (`'notDetermined' | 'denied' | 'granted'`) into the
+  /// enum. Unknown values collapse to [notDetermined] so stale platform
+  /// responses fail-closed.
+  static HealthPermissionStatus fromWire(String? wire) {
+    switch (wire) {
+      case 'granted':
+        return HealthPermissionStatus.granted;
+      case 'denied':
+        return HealthPermissionStatus.denied;
+      case 'notDetermined':
+      default:
+        return HealthPermissionStatus.notDetermined;
+    }
+  }
+}
+
 enum RecordingMethod {
   unknown,
   active,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   intl: '>=0.18.0 <0.21.0'
-  device_info_plus: '^12.1.0'
+  device_info_plus: '>=12.1.0 <14.0.0'
   json_annotation: ^4.9.0
   carp_serializable: ^2.0.1 # polymorphic json serialization
 

--- a/test/support/stub_device_info.dart
+++ b/test/support/stub_device_info.dart
@@ -64,6 +64,7 @@ class StubDeviceInfoPlugin implements DeviceInfoPlugin {
           'physicalRamSize': 8192,
           'availableRamSize': 4096,
           'isiOSAppOnMac': false,
+          'isiOSAppOnVision': false,
           'utsname': {
             'sysname': 'stub-ios-sysname',
             'nodename': 'stub-ios-nodename',

--- a/test/support/stub_device_info.dart
+++ b/test/support/stub_device_info.dart
@@ -43,7 +43,6 @@ class StubDeviceInfoPlugin implements DeviceInfoPlugin {
           'type': 'stub-type',
           'isPhysicalDevice': true,
           'systemFeatures': <String>[],
-          'serialNumber': 'stub-serial',
           'isLowRamDevice': false,
         }),
       );

--- a/test/unit/health_plugin_permissions_test.dart
+++ b/test/unit/health_plugin_permissions_test.dart
@@ -87,6 +87,74 @@ void main() {
     });
   });
 
+  group('accurateAuthorizationStatus', () {
+    test('throws when types list is empty', () {
+      expect(
+        () => ctx.health.accurateAuthorizationStatus(types: const []),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('parses granted wire string', () async {
+      ctx.channel.when('accurateAuthorizationStatus', 'granted');
+
+      final status = await ctx.health.accurateAuthorizationStatus(
+        types: [HealthDataType.WORKOUT, HealthDataType.ACTIVE_ENERGY_BURNED],
+      );
+
+      expect(status, HealthPermissionStatus.granted);
+      final call = ctx.channel.lastCallFor('accurateAuthorizationStatus');
+      expect(call, isNotNull);
+      final args = Map<String, dynamic>.from(call!.arguments as Map);
+      expect(
+        args['types'],
+        [
+          HealthDataType.WORKOUT.name,
+          HealthDataType.ACTIVE_ENERGY_BURNED.name,
+        ],
+      );
+    });
+
+    test('parses denied wire string', () async {
+      ctx.channel.when('accurateAuthorizationStatus', 'denied');
+
+      final status = await ctx.health.accurateAuthorizationStatus(
+        types: [HealthDataType.WORKOUT],
+      );
+
+      expect(status, HealthPermissionStatus.denied);
+    });
+
+    test('parses notDetermined wire string', () async {
+      ctx.channel.when('accurateAuthorizationStatus', 'notDetermined');
+
+      final status = await ctx.health.accurateAuthorizationStatus(
+        types: [HealthDataType.WORKOUT],
+      );
+
+      expect(status, HealthPermissionStatus.notDetermined);
+    });
+
+    test('unknown wire string collapses to notDetermined (fail-closed)', () async {
+      ctx.channel.when('accurateAuthorizationStatus', 'something-weird');
+
+      final status = await ctx.health.accurateAuthorizationStatus(
+        types: [HealthDataType.WORKOUT],
+      );
+
+      expect(status, HealthPermissionStatus.notDetermined);
+    });
+
+    test('null channel response collapses to notDetermined (fail-closed)', () async {
+      // Don't stub — harness returns null for unconfigured methods.
+      final status = await ctx.health.accurateAuthorizationStatus(
+        types: [HealthDataType.WORKOUT],
+      );
+
+      expect(status, HealthPermissionStatus.notDetermined);
+    });
+  });
+
   group('Availability', () {
     test('getHealthConnectSdkStatus maps native status', () async {
       ctx.channel.when('getHealthConnectSdkStatus', HealthConnectSdkStatus.sdkAvailable.nativeValue);
@@ -149,6 +217,35 @@ void main() {
       final authorized = await ctx.health.requestHealthDataInBackgroundAuthorization();
 
       expect(authorized, isTrue);
+    });
+  });
+
+  group('isHealthConnectPackageInstalled', () {
+    test('returns channel true on Android path', () async {
+      ctx.channel.when('isHealthConnectPackageInstalled', true);
+
+      final installed = await ctx.health.isHealthConnectPackageInstalled();
+
+      expect(installed, isTrue);
+      // On test host (macOS/Linux) Dart does NOT short-circuit, so the
+      // channel call is observed.
+      final call = ctx.channel.lastCallFor('isHealthConnectPackageInstalled');
+      expect(call, isNotNull);
+    });
+
+    test('returns channel false when package missing', () async {
+      ctx.channel.when('isHealthConnectPackageInstalled', false);
+
+      final installed = await ctx.health.isHealthConnectPackageInstalled();
+
+      expect(installed, isFalse);
+    });
+
+    test('null channel response coerces to false', () async {
+      // Don't stub — harness returns null.
+      final installed = await ctx.health.isHealthConnectPackageInstalled();
+
+      expect(installed, isFalse);
     });
   });
 }

--- a/test/unit/health_plugin_writes_test.dart
+++ b/test/unit/health_plugin_writes_test.dart
@@ -133,6 +133,275 @@ void main() {
     });
   });
 
+  group('writeWorkoutData — idempotency + zone offsets', () {
+    // Pulls the most recent writeWorkoutData args map off the channel harness.
+    Future<Map<String, dynamic>> callAndCaptureArgs({
+      required Future<bool> Function() action,
+    }) async {
+      ctx.channel.when('writeWorkoutData', true);
+      final success = await action();
+      expect(success, isTrue);
+      final call = ctx.channel.lastCallFor('writeWorkoutData');
+      expect(call, isNotNull);
+      return Map<String, dynamic>.from(call!.arguments as Map);
+    }
+
+    test('backward compat: upstream call shape preserved when no new args', () async {
+      final args = await callAndCaptureArgs(
+        action: () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+        ),
+      );
+
+      // Pre-existing keys still populated exactly as upstream
+      expect(args['activityType'], HealthWorkoutActivityType.RUNNING.name);
+      expect(args['startTime'], HealthFixtures.start.millisecondsSinceEpoch);
+      expect(args['endTime'], HealthFixtures.end.millisecondsSinceEpoch);
+      expect(args['recordingMethod'], RecordingMethod.automatic.toInt());
+      // Every new key is present but null / default — so platform code sees
+      // the same effective payload as before the extension.
+      expect(args['syncIdentifier'], isNull);
+      expect(args['syncVersion'], isNull);
+      expect(args['clientRecordId'], isNull);
+      expect(args['clientRecordVersion'], isNull);
+      expect(args['startZoneOffsetSeconds'], isNull);
+      expect(args['endZoneOffsetSeconds'], isNull);
+      expect(args['deviceType'], isNull);
+      expect(args['iosExtraMetadata'], isNull);
+      expect(args['useActiveEnergy'], isFalse);
+    });
+
+    test('forwards syncIdentifier + syncVersion to iOS channel', () async {
+      final args = await callAndCaptureArgs(
+        action: () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+          syncIdentifier: 'session-42',
+          syncVersion: 3,
+        ),
+      );
+
+      expect(args['syncIdentifier'], 'session-42');
+      expect(args['syncVersion'], 3);
+    });
+
+    test('syncIdentifier without syncVersion throws ArgumentError', () {
+      expect(
+        () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+          syncIdentifier: 'session-42',
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('syncVersion without syncIdentifier throws ArgumentError', () {
+      expect(
+        () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+          syncVersion: 3,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('forwards clientRecordId + clientRecordVersion to Health Connect', () async {
+      final args = await callAndCaptureArgs(
+        action: () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+          clientRecordId: 'session-42',
+          clientRecordVersion: 3,
+        ),
+      );
+
+      expect(args['clientRecordId'], 'session-42');
+      expect(args['clientRecordVersion'], 3);
+    });
+
+    test('clientRecordId without clientRecordVersion throws ArgumentError', () {
+      expect(
+        () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+          clientRecordId: 'session-42',
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('clientRecordVersion without clientRecordId throws ArgumentError', () {
+      expect(
+        () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+          clientRecordVersion: 3,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('zone offsets serialised to total seconds', () async {
+      final args = await callAndCaptureArgs(
+        action: () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+          startZoneOffset: const Duration(hours: 5, minutes: 30),
+          endZoneOffset: const Duration(hours: -8),
+        ),
+      );
+
+      expect(args['startZoneOffsetSeconds'], 19800);
+      expect(args['endZoneOffsetSeconds'], -28800);
+    });
+
+    test('null zone offsets serialise as null, not zero', () async {
+      final args = await callAndCaptureArgs(
+        action: () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+        ),
+      );
+
+      // Must distinguish "no offset provided" from "UTC" on the native side.
+      expect(args['startZoneOffsetSeconds'], isNull);
+      expect(args['endZoneOffsetSeconds'], isNull);
+    });
+
+    test('deviceType forwarded to Android channel', () async {
+      final args = await callAndCaptureArgs(
+        action: () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+          deviceType: 7,
+        ),
+      );
+
+      expect(args['deviceType'], 7);
+    });
+
+    test('iosExtraMetadata forwarded as Map', () async {
+      final args = await callAndCaptureArgs(
+        action: () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+          iosExtraMetadata: const {
+            'HKMetadataKeyWorkoutBrandName': 'Magic',
+            'fit.magic.workoutTitle': 'Morning Run',
+          },
+        ),
+      );
+
+      final extras = Map<String, Object>.from(args['iosExtraMetadata'] as Map);
+      expect(extras['HKMetadataKeyWorkoutBrandName'], 'Magic');
+      expect(extras['fit.magic.workoutTitle'], 'Morning Run');
+    });
+
+    test('useActiveEnergy defaults to false', () async {
+      final args = await callAndCaptureArgs(
+        action: () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+        ),
+      );
+
+      expect(args['useActiveEnergy'], isFalse);
+    });
+
+    test('useActiveEnergy: true forwarded', () async {
+      final args = await callAndCaptureArgs(
+        action: () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+          useActiveEnergy: true,
+        ),
+      );
+
+      expect(args['useActiveEnergy'], isTrue);
+    });
+
+    test('platform-invalid recordingMethod still rejected on iOS', () {
+      if (!Platform.isIOS) return;
+      expect(
+        () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+          recordingMethod: RecordingMethod.active,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('native channel false return propagates', () async {
+      ctx.channel.when('writeWorkoutData', false);
+
+      final success = await ctx.health.writeWorkoutData(
+        activityType: HealthWorkoutActivityType.RUNNING,
+        start: HealthFixtures.start,
+        end: HealthFixtures.end,
+        syncIdentifier: 'session-42',
+        syncVersion: 1,
+      );
+
+      expect(success, isFalse);
+    });
+
+    test('all new params forwarded together', () async {
+      final args = await callAndCaptureArgs(
+        action: () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+          totalEnergyBurned: 250,
+          title: 'Magic Workout',
+          recordingMethod: RecordingMethod.automatic,
+          syncIdentifier: 'session-42',
+          syncVersion: 1,
+          clientRecordId: 'session-42',
+          clientRecordVersion: 1,
+          startZoneOffset: const Duration(hours: 1),
+          endZoneOffset: const Duration(hours: 1),
+          deviceType: 2,
+          iosExtraMetadata: const {'fit.magic.workoutTitle': 'Magic Workout'},
+          useActiveEnergy: true,
+        ),
+      );
+
+      expect(args['totalEnergyBurned'], 250);
+      expect(args['title'], 'Magic Workout');
+      expect(args['recordingMethod'], RecordingMethod.automatic.toInt());
+      expect(args['syncIdentifier'], 'session-42');
+      expect(args['syncVersion'], 1);
+      expect(args['clientRecordId'], 'session-42');
+      expect(args['clientRecordVersion'], 1);
+      expect(args['startZoneOffsetSeconds'], 3600);
+      expect(args['endZoneOffsetSeconds'], 3600);
+      expect(args['deviceType'], 2);
+      expect(args['useActiveEnergy'], isTrue);
+      expect(
+        Map<String, Object>.from(args['iosExtraMetadata'] as Map)['fit.magic.workoutTitle'],
+        'Magic Workout',
+      );
+    });
+  });
+
   group('writeBloodOxygen', () {
     test('rejects invalid time range', () {
       expect(

--- a/test/unit/health_plugin_writes_test.dart
+++ b/test/unit/health_plugin_writes_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io' show Platform;
 
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:health/health.dart';
 
@@ -361,6 +362,80 @@ void main() {
       );
 
       expect(success, isFalse);
+    });
+
+    test(
+        'structured native error (permission) propagates as '
+        'PlatformException the caller can classify', () async {
+      // Simulate the Android `result.error("SECURITY_EXCEPTION", ...)` or
+      // iOS `FlutterError(code: "HK_AUTHORIZATION_DENIED", ...)` path. The
+      // plugin no longer swallows native errors into `success == false`;
+      // callers receive a typed PlatformException they can switch on.
+      await ctx.channel.tearDown();
+      await ctx.channel.setUp(
+        responder: (call) async {
+          if (call.method == 'writeWorkoutData') {
+            throw PlatformException(
+              code: 'SECURITY_EXCEPTION',
+              message: 'WRITE_EXERCISE permission not granted',
+              details: {'exceptionClass': 'java.lang.SecurityException'},
+            );
+          }
+          return null;
+        },
+      );
+
+      expect(
+        () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+          syncIdentifier: 'session-42',
+          syncVersion: 1,
+        ),
+        throwsA(
+          isA<PlatformException>().having(
+            (e) => e.code,
+            'code',
+            'SECURITY_EXCEPTION',
+          ),
+        ),
+      );
+    });
+
+    test(
+        'structured native error (HealthKit authorization denied) '
+        'propagates as PlatformException', () async {
+      await ctx.channel.tearDown();
+      await ctx.channel.setUp(
+        responder: (call) async {
+          if (call.method == 'writeWorkoutData') {
+            throw PlatformException(
+              code: 'HK_AUTHORIZATION_DENIED',
+              message: 'Authorization denied by user',
+              details: {'domain': 'HKErrorDomain', 'nativeCode': 4},
+            );
+          }
+          return null;
+        },
+      );
+
+      expect(
+        () => ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.RUNNING,
+          start: HealthFixtures.start,
+          end: HealthFixtures.end,
+          syncIdentifier: 'session-42',
+          syncVersion: 1,
+        ),
+        throwsA(
+          isA<PlatformException>().having(
+            (e) => e.code,
+            'code',
+            'HK_AUTHORIZATION_DENIED',
+          ),
+        ),
+      );
     });
 
     test('all new params forwarded together', () async {


### PR DESCRIPTION
## Motivation

Apps that sync workouts from another device or backend into HealthKit /
Health Connect need reliable dedup across reinstalls, OS migrations, and
repeated network retries. Both platforms expose first-class upsert
mechanisms for exactly this — `HKMetadataKeySyncIdentifier` on iOS and
`Metadata.clientRecordId` on Health Connect — but `health` currently
doesn't surface either, forcing consumers to either tolerate duplicate
records or ship their own native code on top of the plugin.

This PR extends `writeWorkoutData` to pass these platform-native upsert
keys through, along with a couple of adjacent gaps (zone offsets,
active-vs-total calories, accurate iOS authorization state, and Health
Connect install detection). Every addition is backward-compatible — no-
new-params callers get byte-for-byte identical behaviour.

## What's new

### `writeWorkoutData` parameters (all optional)

| Param | Platform | Role |
|---|---|---|
| `syncIdentifier` + `syncVersion` | iOS | `HKMetadataKeySyncIdentifier` + `HKMetadataKeySyncVersion` — HealthKit's documented upsert mechanism |
| `clientRecordId` + `clientRecordVersion` | Android | `Metadata.clientRecordId` / `clientRecordVersion` — HC's documented upsert mechanism |
| `startZoneOffset` / `endZoneOffset` | Android | Attached to `ExerciseSessionRecord` and linked records; preserves local-day aggregation across timezone changes |
| `deviceType` | Android | `Device(type = ...)` for auto/active `Metadata` factories |
| `iosExtraMetadata` | iOS | Arbitrary keys merged into the `HKWorkout` metadata dict |
| `useActiveEnergy` | Android | When true, emits `ActiveCaloriesBurnedRecord` instead of `TotalCaloriesBurnedRecord` (excludes BMR, which can over-report the workout contribution) |

### New methods

- **`accurateAuthorizationStatus({required types})`** — returns a
  three-valued `HealthPermissionStatus` (`notDetermined` / `denied` /
  `granted`). iOS reads `HKHealthStore.authorizationStatus(for:)` per
  type and aggregates worst-case. Android delegates to
  `getGrantedPermissions().containsAll(...)`. Fills the gap left by
  `hasPermissions`, which deliberately returns `null` on iOS READ
  intent.

- **`isHealthConnectPackageInstalled()`** — returns whether the
  `com.google.android.apps.healthdata` package is installed. Splits
  the ambiguity of `getHealthConnectSdkStatus`'s
  `sdkUnavailableProviderUpdateRequired` state so callers can route
  the user to an **install** vs **update** CTA.

## Design notes

### iOS metadata merge order

`iosExtraMetadata` is merged **before** the sync-identifier keys, so a
caller cannot accidentally overwrite `HKMetadataKeySyncIdentifier` /
`HKMetadataKeySyncVersion` through the extras map. When no new params
are supplied, the `HKWorkout` metadata dict stays `nil`.

### Android linked-record IDs

`ExerciseSessionRecord`, linked `DistanceRecord`, and linked calorie
record each get a distinct `clientRecordId`:

- session:  `<clientRecordId>`
- distance: `<clientRecordId>:distance`
- calories: `<clientRecordId>:calories`

This prevents HC from rejecting the insert as a duplicate-upsert batch.

### Zone offset safety

`ZoneOffset.ofTotalSeconds` throws `DateTimeException` for values
outside UTC±18h; a new `safeZoneOffset()` helper catches and logs a
warning rather than surfacing an uncaught platform error.

### Validation

Both id/version pairs are checked both directions at the Dart layer:
providing only one half throws `ArgumentError` — catches programmer
error before the method channel call.

### `device_info_plus` constraint

Also includes a one-line pubspec change relaxing the `device_info_plus`
dependency from `^12.1.0` to `>=12.1.0 <14.0.0`. The plugin only reads
`androidInfo.id` and `iosInfo.identifierForVendor` — both fields are
unchanged across v12 and v13. Blocking consumers on v13 had no
source-level reason, and the full test suite is green against both
majors.

## Known limitation

Rewriting a workout with a **higher** `clientRecordVersion` that omits
`totalDistance` or `totalEnergyBurned` leaves the old linked record in
place (the session's upsert succeeds but the linked records are never
revisited). Deliberately out of scope for this PR — all the use cases
we've validated rewrite with all three fields on every call. Happy to
add a separate `deleteLinkedRecordsOnRewrite` opt-in in a follow-up if
you'd prefer to land the fix here.

## Tests

- **25 new Dart unit tests** added via the existing
  `HealthTestContext` harness:
  - 16 in `test/unit/health_plugin_writes_test.dart` — every new
    `writeWorkoutData` param, validation rules, backward-compat
  - 9 in `test/unit/health_plugin_permissions_test.dart` — wire
    string parsing, empty-types guard, null-response fail-closed
- **1 incidental test fix** in `test/support/stub_device_info.dart`:
  adds `isiOSAppOnVision` (required by `device_info_plus` 12.1+) and
  drops the dead `serialNumber` key (removed in v13). Without the
  `isiOSAppOnVision` addition the existing suite was already red on
  every `setUp()` that calls `Health()`.

**All tests pass: 77/77 green** on `flutter test`.

## Example app demo

The example app ships a **Test Idempotency** button that exercises the
full upsert flow end-to-end on a connected device. Tapping it writes
the same workout twice with identical sync/client ids, then queries
back and reports the count — should always be `1` regardless of tap
count. Day-bucketed session id so tomorrow's tap produces a fresh
record.

Verified on a **Pixel 7 running Android 16** (Health Connect provider
installed): 2 button presses × 2 writes each = **4 total writes → 1
record** in Health Connect. iOS verification pending a paired-device
test, happy to pair with a reviewer to run it if helpful.

To reproduce:

```bash
cd example
flutter run -d <device-id>
# In the app: Authorize → tap "Test Idempotency" 2–3 times
# → read the on-screen result
# → open Apple Health / Health Connect to visually confirm
```

## Commits

1. `76faee9` — test: add isiOSAppOnVision to StubDeviceInfoPlugin
2. `cd2ab57` — feat(writeWorkoutData): idempotent-write metadata, zone offsets, active-energy opt-in
3. `ddbdafd` — feat: accurateAuthorizationStatus + isHealthConnectPackageInstalled
4. `bd5ca78` — docs(example): idempotency demo button
5. `76718f5` — chore: allow device_info_plus 13.x