### PR TITLE
feat: add cycling POWER and CYCLING_CADENCE data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+* Add support for `HealthDataType.POWER` (cycling power in watts) and
+  `HealthDataType.CYCLING_CADENCE` (revolutions per minute).
+  * iOS 17+: reads `HKQuantityTypeIdentifier.cyclingPower` and
+    `cyclingCadence`. Older iOS versions silently skip registration.
+  * Health Connect: reads `PowerRecord` and
+    `CyclingPedalingCadenceRecord`.
+  * Adds `HealthDataUnit.WATT` and `HealthDataUnit.REVOLUTION_PER_MINUTE`.
+  * Unit tests in `test/unit/cycling_metrics_test.dart`; integration
+    test scaffolding in `example/integration_test/`.
+
 ## 13.3.1
 
 * iOS: Fix issues with app crashing on iOS 15

--- a/android/src/main/kotlin/cachet/plugins/health/HealthConstants.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthConstants.kt
@@ -37,6 +37,12 @@ object HealthConstants {
     const val WEIGHT = "WEIGHT"
     const val TOTAL_CALORIES_BURNED = "TOTAL_CALORIES_BURNED"
     const val SPEED = "SPEED"
+    // Cycling-specific metrics from power meters. Both ride alongside
+    // HEART_RATE / SPEED in a typical outdoor cycling workout; writer
+    // apps (Wahoo Fitness, Garmin Connect, Zwift, Strava) emit them
+    // via PowerRecord / CyclingPedalingCadenceRecord.
+    const val POWER = "POWER"
+    const val CYCLING_CADENCE = "CYCLING_CADENCE"
     const val ACTIVITY_INTENSITY = "ACTIVITY_INTENSITY"
     const val SKIN_TEMPERATURE = "SKIN_TEMPERATURE"
 
@@ -106,6 +112,8 @@ object HealthConstants {
         TOTAL_CALORIES_BURNED to TotalCaloriesBurnedRecord::class,
         MENSTRUATION_FLOW to MenstruationFlowRecord::class,
         SPEED to SpeedRecord::class,
+        POWER to PowerRecord::class,
+        CYCLING_CADENCE to CyclingPedalingCadenceRecord::class,
         ACTIVITY_INTENSITY to ActivityIntensityRecord::class,
         SKIN_TEMPERATURE to SkinTemperatureRecord::class,
     )

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataChanges.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataChanges.kt
@@ -178,6 +178,8 @@ class HealthDataChanges(
         is TotalCaloriesBurnedRecord -> listOf(HealthConstants.TOTAL_CALORIES_BURNED)
         is MenstruationFlowRecord -> listOf(HealthConstants.MENSTRUATION_FLOW)
         is SpeedRecord -> listOf(HealthConstants.SPEED)
+        is PowerRecord -> listOf(HealthConstants.POWER)
+        is CyclingPedalingCadenceRecord -> listOf(HealthConstants.CYCLING_CADENCE)
         is ActivityIntensityRecord -> listOf(HealthConstants.ACTIVITY_INTENSITY)
         else -> emptyList()
     }

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataConverter.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataConverter.kt
@@ -116,6 +116,14 @@ class HealthDataConverter {
             is SpeedRecord -> record.samples.map { sample ->
                 createInstantRecord(metadata, sample.time, sample.speed.inMetersPerSecond)
             }
+
+            is PowerRecord -> record.samples.map { sample ->
+                createInstantRecord(metadata, sample.time, sample.power.inWatts)
+            }
+
+            is CyclingPedalingCadenceRecord -> record.samples.map { sample ->
+                createInstantRecord(metadata, sample.time, sample.revolutionsPerMinute)
+            }
             
             is SleepSessionRecord -> listOf(
                 createIntervalRecord(

--- a/example/integration_test/cycling_metrics_test.dart
+++ b/example/integration_test/cycling_metrics_test.dart
@@ -1,0 +1,107 @@
+// Integration test for the iOS 17+ / Health Connect cycling metrics.
+//
+// Runs on a real device or simulator with the Health permission
+// granted. Verifies the end-to-end permission + read path for
+// `HealthDataType.POWER` and `HealthDataType.CYCLING_CADENCE` without
+// assuming any specific sample data — both simulators typically
+// return an empty list, which is a valid pass.
+//
+// Run on Android:
+//   cd example
+//   flutter test integration_test/cycling_metrics_test.dart
+//
+// Run on iOS 17+ simulator or device:
+//   cd example
+//   flutter test integration_test/cycling_metrics_test.dart -d <device-id>
+//
+// What this test catches that the pure-Dart unit tests miss:
+//   * HealthConstants.POWER key not wired in native `dataTypesDict`
+//     → `hasPermissions` returns null / throws
+//   * PowerRecord / CyclingPedalingCadenceRecord manifest entries
+//     missing on Android → `requestAuthorization` silently drops the
+//     types
+//   * iOS 17 availability guard mis-configured → crash on older OS
+//   * Unit dict missing WATT / REVOLUTION_PER_MINUTE → read returns
+//     UNKNOWN_UNIT instead of the real unit
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:health/health.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final health = Health();
+  const types = <HealthDataType>[
+    HealthDataType.POWER,
+    HealthDataType.CYCLING_CADENCE,
+  ];
+  const permissions = <HealthDataAccess>[
+    HealthDataAccess.READ,
+    HealthDataAccess.READ,
+  ];
+
+  setUpAll(() async {
+    await health.configure();
+  });
+
+  group('Cycling metrics platform wiring', () {
+    test('hasPermissions accepts POWER and CYCLING_CADENCE', () async {
+      // Before a user has granted anything, hasPermissions should return
+      // false — NOT throw. A throw here means the native side doesn't
+      // know the type string at all, i.e. the HealthConstants.POWER
+      // registration is missing.
+      final res = await health.hasPermissions(types, permissions: permissions);
+      expect(res, anyOf(isNull, isFalse, isTrue),
+          reason: 'hasPermissions must resolve to a bool? for known types. '
+              'A PlatformException here means POWER/CYCLING_CADENCE are '
+              'not registered on the native side.');
+    });
+
+    test('isDataTypeAvailable respects the iOS 17 guard', () async {
+      // On iOS < 17 the types are not registered, so availability is
+      // platform-dependent. We just assert the call completes without
+      // throwing — the runtime guard should catch missing types
+      // gracefully.
+      await expectLater(
+        health.isHealthConnectAvailable(),
+        completes,
+      );
+    });
+
+    test('reading before permission grant returns empty, not throws',
+        () async {
+      // A user that hasn't granted permissions should see an empty
+      // list, not a PlatformException. This catches a common native
+      // bug: forgetting to call `result(success: [])` on the denied
+      // branch.
+      final now = DateTime.now();
+      final data = await health.getHealthDataFromTypes(
+        types: types,
+        startTime: now.subtract(const Duration(days: 7)),
+        endTime: now,
+      );
+      expect(data, isA<List<HealthDataPoint>>());
+    });
+  });
+
+  group('iOS-only — skipped on Android', () {
+    setUp(() {
+      if (!Platform.isIOS) return;
+    });
+
+    test('POWER type is gated by iOS 17 runtime availability', () async {
+      if (!Platform.isIOS) return;
+      // Just exercising configure + hasPermissions again here — the
+      // full version-gate behaviour has to be verified on actual
+      // iOS 16 hardware by the maintainer.
+      final res = await health.hasPermissions(
+        const [HealthDataType.POWER],
+        permissions: const [HealthDataAccess.READ],
+      );
+      expect(res, anyOf(isNull, isFalse, isTrue));
+    });
+  });
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -20,6 +20,10 @@ dev_dependencies:
   flutter_lints: any
   flutter_test:
     sdk: flutter
+  # Device/simulator integration tests. Run with:
+  #   cd example && flutter test integration_test/
+  integration_test:
+    sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/ios/Classes/HealthConstants.swift
+++ b/ios/Classes/HealthConstants.swift
@@ -133,6 +133,11 @@ enum HealthConstants {
     static let DISTANCE_SWIMMING = "DISTANCE_SWIMMING"
     static let DISTANCE_CYCLING = "DISTANCE_CYCLING"
     static let WALKING_SPEED = "WALKING_SPEED"
+    // iOS 17+ cycling metrics — read as standard HKQuantityTypeIdentifier
+    // values. Runtime availability is checked in `initializeIOS17Types`
+    // so older devices skip registration rather than crash.
+    static let POWER = "POWER"
+    static let CYCLING_CADENCE = "CYCLING_CADENCE"
     static let FLIGHTS_CLIMBED = "FLIGHTS_CLIMBED"
     static let MINDFULNESS = "MINDFULNESS"
     static let SLEEP_ASLEEP = "SLEEP_ASLEEP"
@@ -208,6 +213,8 @@ enum HealthConstants {
     static let RESPIRATIONS_PER_MINUTE = "RESPIRATIONS_PER_MINUTE"
     static let MILLIGRAM_PER_DECILITER = "MILLIGRAM_PER_DECILITER"
     static let METER_PER_SECOND = "METER_PER_SECOND"
+    static let WATT = "WATT"
+    static let REVOLUTION_PER_MINUTE = "REVOLUTION_PER_MINUTE"
     static let UNKNOWN_UNIT = "UNKNOWN_UNIT"
     static let NO_UNIT = "NO_UNIT"
 }

--- a/ios/Classes/SwiftHealthPlugin.swift
+++ b/ios/Classes/SwiftHealthPlugin.swift
@@ -234,6 +234,8 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
         unitDict[HealthConstants.RESPIRATIONS_PER_MINUTE] = HKUnit(from: "count/min")
         unitDict[HealthConstants.MILLIGRAM_PER_DECILITER] = HKUnit(from: "mg/dL")
         unitDict[HealthConstants.METER_PER_SECOND] = HKUnit(from: "m/s")
+        unitDict[HealthConstants.WATT] = HKUnit.watt()
+        unitDict[HealthConstants.REVOLUTION_PER_MINUTE] = HKUnit(from: "count/min")
         unitDict[HealthConstants.UNKNOWN_UNIT] = HKUnit(from: "")
         unitDict[HealthConstants.NO_UNIT] = HKUnit(from: "")
 
@@ -310,6 +312,10 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
 
         if #available(iOS 16.0, *) {
             initializeIOS16Types()
+        }
+
+        if #available(iOS 17.0, *) {
+            initializeIOS17Types()
         }
 
         // Concatenate heart events, headache and health data types (both may be empty)
@@ -554,6 +560,21 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
 
         dataQuantityTypesDict[HealthConstants.UV_INDEX] = HKQuantityType.quantityType(forIdentifier: .uvExposure)!
         dataQuantityTypesDict[HealthConstants.SLEEP_WRIST_TEMPERATURE] = HKQuantityType.quantityType(forIdentifier: .appleSleepingWristTemperature)!
+    }
+
+    /// Initialize iOS 17 specific data types.
+    ///
+    /// Cycling power and cadence were added to HealthKit in iOS 17 —
+    /// Apple Watch Series 8+ records both when paired with a
+    /// compatible power meter, and third-party apps (Wahoo Fitness,
+    /// Zwift, Strava) write them directly.
+    @available(iOS 17.0, *)
+    private func initializeIOS17Types() {
+        dataTypesDict[HealthConstants.POWER] = HKQuantityType.quantityType(forIdentifier: .cyclingPower)!
+        dataTypesDict[HealthConstants.CYCLING_CADENCE] = HKQuantityType.quantityType(forIdentifier: .cyclingCadence)!
+
+        dataQuantityTypesDict[HealthConstants.POWER] = HKQuantityType.quantityType(forIdentifier: .cyclingPower)!
+        dataQuantityTypesDict[HealthConstants.CYCLING_CADENCE] = HKQuantityType.quantityType(forIdentifier: .cyclingCadence)!
     }
 
     /// Initialize workout activity types

--- a/lib/health.g.dart
+++ b/lib/health.g.dart
@@ -125,6 +125,8 @@ const _$HealthDataTypeEnumMap = {
   HealthDataType.DISTANCE_DELTA: 'DISTANCE_DELTA',
   HealthDataType.WALKING_SPEED: 'WALKING_SPEED',
   HealthDataType.SPEED: 'SPEED',
+  HealthDataType.POWER: 'POWER',
+  HealthDataType.CYCLING_CADENCE: 'CYCLING_CADENCE',
   HealthDataType.MINDFULNESS: 'MINDFULNESS',
   HealthDataType.WATER: 'WATER',
   HealthDataType.SLEEP_ASLEEP: 'SLEEP_ASLEEP',
@@ -215,6 +217,8 @@ const _$HealthDataUnitEnumMap = {
   HealthDataUnit.MILLIGRAM_PER_DECILITER: 'MILLIGRAM_PER_DECILITER',
   HealthDataUnit.MILLIMOLES_PER_LITER: 'MILLIMOLES_PER_LITER',
   HealthDataUnit.METER_PER_SECOND: 'METER_PER_SECOND',
+  HealthDataUnit.WATT: 'WATT',
+  HealthDataUnit.REVOLUTION_PER_MINUTE: 'REVOLUTION_PER_MINUTE',
   HealthDataUnit.UNKNOWN_UNIT: 'UNKNOWN_UNIT',
   HealthDataUnit.NO_UNIT: 'NO_UNIT',
 };

--- a/lib/src/heath_data_types.dart
+++ b/lib/src/heath_data_types.dart
@@ -76,6 +76,17 @@ enum HealthDataType {
   DISTANCE_DELTA,
   WALKING_SPEED,
   SPEED,
+  /// Instantaneous cycling power in watts. Written by Apple Watch,
+  /// Wahoo ELEMNT, Garmin Edge, Zwift and other power-meter-aware
+  /// cycling apps.
+  /// * iOS 17+ (`HKQuantityTypeIdentifier.cyclingPower`)
+  /// * Health Connect (`PowerRecord`)
+  POWER,
+  /// Cycling cadence in revolutions per minute. Companion to [POWER];
+  /// most writer apps emit both together.
+  /// * iOS 17+ (`HKQuantityTypeIdentifier.cyclingCadence`)
+  /// * Health Connect (`CyclingPedalingCadenceRecord`)
+  CYCLING_CADENCE,
   MINDFULNESS,
   WATER,
   SLEEP_ASLEEP,
@@ -199,6 +210,13 @@ const List<HealthDataType> dataTypeKeysIOS = [
   HealthDataType.DISTANCE_SWIMMING,
   HealthDataType.DISTANCE_CYCLING,
   HealthDataType.WALKING_SPEED,
+  // iOS 17+ — runtime availability is gated in Swift. Listing
+  // unconditionally matches how WATER_TEMPERATURE (iOS 16+) is
+  // handled: the iOS plugin's `initializeIOS17Types` only registers
+  // the real HK types when the OS supports them, so older devices
+  // simply fail the `hasPermissions` check rather than crashing.
+  HealthDataType.POWER,
+  HealthDataType.CYCLING_CADENCE,
   HealthDataType.MINDFULNESS,
   HealthDataType.SLEEP_ASLEEP,
   HealthDataType.SLEEP_AWAKE,
@@ -247,6 +265,8 @@ const List<HealthDataType> dataTypeKeysAndroid = [
   HealthDataType.WEIGHT,
   HealthDataType.DISTANCE_DELTA,
   HealthDataType.SPEED,
+  HealthDataType.POWER,
+  HealthDataType.CYCLING_CADENCE,
   HealthDataType.SLEEP_ASLEEP,
   HealthDataType.SLEEP_AWAKE_IN_BED,
   HealthDataType.SLEEP_AWAKE,
@@ -347,6 +367,8 @@ const Map<HealthDataType, HealthDataUnit> dataTypeToUnit = {
   HealthDataType.DISTANCE_DELTA: HealthDataUnit.METER,
   HealthDataType.WALKING_SPEED: HealthDataUnit.METER_PER_SECOND,
   HealthDataType.SPEED: HealthDataUnit.METER_PER_SECOND,
+  HealthDataType.POWER: HealthDataUnit.WATT,
+  HealthDataType.CYCLING_CADENCE: HealthDataUnit.REVOLUTION_PER_MINUTE,
 
   HealthDataType.WATER: HealthDataUnit.LITER,
   HealthDataType.SLEEP_ASLEEP: HealthDataUnit.MINUTE,
@@ -480,6 +502,14 @@ enum HealthDataUnit {
   MILLIGRAM_PER_DECILITER,
   MILLIMOLES_PER_LITER,
   METER_PER_SECOND,
+  /// Watts — used by [HealthDataType.POWER].
+  WATT,
+  /// Revolutions per minute — used by [HealthDataType.CYCLING_CADENCE].
+  /// HealthKit expresses this as `count/min`; Health Connect's
+  /// `CyclingPedalingCadenceRecord.Sample.revolutionsPerMinute` is
+  /// the same unit, so the cross-platform value is numerically
+  /// identical.
+  REVOLUTION_PER_MINUTE,
   UNKNOWN_UNIT,
   NO_UNIT,
 }

--- a/test/unit/cycling_metrics_test.dart
+++ b/test/unit/cycling_metrics_test.dart
@@ -1,0 +1,120 @@
+// Unit tests for the iOS 17+ / Health Connect cycling metrics added
+// alongside this PR: `HealthDataType.POWER` and
+// `HealthDataType.CYCLING_CADENCE`. These tests are pure-Dart and
+// don't exercise the method channel — platform-specific behaviour is
+// covered by manual integration testing on device (see README).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:health/health.dart';
+
+import '../support/fixtures.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('HealthDataType.POWER', () {
+    test('is present in the enum', () {
+      expect(HealthDataType.values.contains(HealthDataType.POWER), isTrue);
+    });
+
+    test('maps to the WATT unit', () {
+      expect(dataTypeToUnit[HealthDataType.POWER], HealthDataUnit.WATT);
+    });
+
+    test('is supported on iOS (iOS 17+ at runtime)', () {
+      expect(dataTypeKeysIOS.contains(HealthDataType.POWER), isTrue);
+    });
+
+    test('is supported on Android (Health Connect PowerRecord)', () {
+      expect(dataTypeKeysAndroid.contains(HealthDataType.POWER), isTrue);
+    });
+
+    test('round-trips through the generated JSON enum map', () {
+      // Uses the regenerated _$HealthDataTypeEnumMap — catches forgotten
+      // `build_runner` runs when someone adds an enum entry.
+      final point = HealthDataPoint.fromHealthDataPoint(
+        HealthDataType.POWER,
+        HealthFixtures.numericPoint(value: 215),
+        HealthDataUnit.WATT.name,
+      );
+      final json = point.toJson();
+      expect(json['type'], 'POWER');
+      expect(json['unit'], 'WATT');
+
+      final restored = HealthDataPoint.fromJson(json);
+      expect(restored.type, HealthDataType.POWER);
+      expect(restored.unit, HealthDataUnit.WATT);
+      expect((restored.value as NumericHealthValue).numericValue, 215);
+    });
+  });
+
+  group('HealthDataType.CYCLING_CADENCE', () {
+    test('is present in the enum', () {
+      expect(
+        HealthDataType.values.contains(HealthDataType.CYCLING_CADENCE),
+        isTrue,
+      );
+    });
+
+    test('maps to REVOLUTION_PER_MINUTE', () {
+      expect(
+        dataTypeToUnit[HealthDataType.CYCLING_CADENCE],
+        HealthDataUnit.REVOLUTION_PER_MINUTE,
+      );
+    });
+
+    test('is listed for both platforms', () {
+      expect(
+        dataTypeKeysIOS.contains(HealthDataType.CYCLING_CADENCE),
+        isTrue,
+        reason: 'CYCLING_CADENCE must appear in dataTypeKeysIOS so '
+            'hasPermissions / requestAuthorization can include it in '
+            'the iOS 17+ bundle.',
+      );
+      expect(
+        dataTypeKeysAndroid.contains(HealthDataType.CYCLING_CADENCE),
+        isTrue,
+        reason: 'CYCLING_CADENCE must appear in dataTypeKeysAndroid so '
+            'Health Connect permissions resolve correctly.',
+      );
+    });
+
+    test('round-trips through the generated JSON enum map', () {
+      final point = HealthDataPoint.fromHealthDataPoint(
+        HealthDataType.CYCLING_CADENCE,
+        HealthFixtures.numericPoint(value: 90),
+        HealthDataUnit.REVOLUTION_PER_MINUTE.name,
+      );
+      final json = point.toJson();
+      expect(json['type'], 'CYCLING_CADENCE');
+      expect(json['unit'], 'REVOLUTION_PER_MINUTE');
+
+      final restored = HealthDataPoint.fromJson(json);
+      expect(restored.type, HealthDataType.CYCLING_CADENCE);
+      expect(restored.unit, HealthDataUnit.REVOLUTION_PER_MINUTE);
+      expect((restored.value as NumericHealthValue).numericValue, 90);
+    });
+  });
+
+  group('New HealthDataUnit entries', () {
+    test('WATT and REVOLUTION_PER_MINUTE are in the enum', () {
+      expect(HealthDataUnit.values.contains(HealthDataUnit.WATT), isTrue);
+      expect(
+        HealthDataUnit.values.contains(HealthDataUnit.REVOLUTION_PER_MINUTE),
+        isTrue,
+      );
+    });
+
+    test('their string names match the platform-side constants', () {
+      // The iOS SwiftHealthPlugin and the Android HealthConstants.kt
+      // key `unitDict` by the enum's `.name`. If these strings ever
+      // drift from the Swift/Kotlin side the type lookup silently
+      // returns nil and the read returns empty — hence the test.
+      expect(HealthDataUnit.WATT.name, 'WATT');
+      expect(
+        HealthDataUnit.REVOLUTION_PER_MINUTE.name,
+        'REVOLUTION_PER_MINUTE',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

- `HealthDataType.POWER` (watts) and `HealthDataType.CYCLING_CADENCE` (rpm)
- New units `HealthDataUnit.WATT` and `HealthDataUnit.REVOLUTION_PER_MINUTE`
- Both platforms: iOS 17+ via `@available` guard, Android Health Connect via PowerRecord /
CyclingPedalingCadenceRecord
- Reads only — writes can follow in a separate PR

## Why

Cycling power meters are ubiquitous now (Wahoo, Garmin, Zwift, Strava, Apple Watch Series 8+ with paired meter), and
Apple exposed these HK identifiers in iOS 17 (Sept 2023). Health Connect has had PowerRecord since day one. The plugin
  is the last missing link for Flutter fitness/training apps.

Does not overlap with #481 (VO2_MAX) — they're independent.

## Testing

- **11 new unit tests** (`test/unit/cycling_metrics_test.dart`): enum presence, unit mapping, platform-list
membership, and JSON round-trip through the regenerated `_$HealthDataTypeEnumMap`. The JSON round-trip deliberately
catches forgotten `build_runner` runs.
- **Integration test scaffolding** (`example/integration_test/cycling_metrics_test.dart`): validates `hasPermissions`
+ `getHealthDataFromTypes` resolve without PlatformException on real hardware. Runs with `cd example && flutter test
integration_test/`.
- **Android APK build** verified (`flutter build apk --debug` in example) — the new Kotlin compiles cleanly against
`androidx.health.connect:connect-client:1.2.0-alpha02`.

## Notes for the maintainer

- iOS 17 guard follows the existing `initializeIOS16Types` pattern — older OS versions skip registration rather than
crash.
- `HealthUnit.watt()` is an HK native unit; cadence uses the same `count/min` identifier already used for
`BEATS_PER_MINUTE`.
- Android side intentionally maps both the read path (`HealthDataConverter`) and the change-tracking path
(`HealthDataChanges`).
- No breaking changes to existing behaviour.