### PR TITLE
Support AGP 9.x compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,8 +21,12 @@ rootProject.allprojects {
     }
 }
 
+def isAgp9OrAbove = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger() >= 9
+
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+if (!isAgp9OrAbove) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     compileSdk 36
@@ -32,8 +36,10 @@ android {
         targetCompatibility JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = '11'
+    if (!isAgp9OrAbove) {
+        kotlinOptions {
+            jvmTarget = '11'
+        }
     }
 
     sourceSets {
@@ -53,7 +59,6 @@ android {
 dependencies {
     def composeBom = platform('androidx.compose:compose-bom:2025.09.00')
     implementation(composeBom)
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.2.10"
 
     implementation("androidx.health.connect:connect-client:1.2.0-alpha02")
     implementation "androidx.fragment:fragment-ktx:1.8.9"


### PR DESCRIPTION
Starting with Android Gradle Plugin 9.0, Kotlin support is embedded in
AGP itself and applying the standalone `kotlin-android` plugin causes a
build failure.

This PR detects the AGP version and skips both the plugin application
and the `kotlinOptions` block when running on AGP 9 or above, keeping
the existing behavior unchanged for AGP 8.x and below.

Same approach used by [file_picker](https://github.com/miguelpruivo/flutter_file_picker)
since version 10.x.