### PR TITLE
Add per-workout flights climbed and swimming stroke count

### DIFF
--- a/ios/Classes/HealthDataReader.swift
+++ b/ios/Classes/HealthDataReader.swift
@@ -261,6 +261,13 @@ class HealthDataReader {
                         "totalEnergyBurnedUnit": "KILOCALORIE",
                         "totalDistance": sample.totalDistance?.doubleValue(for: HKUnit.meter()),
                         "totalDistanceUnit": "METER",
+                        "totalFlightsClimbed": sample.totalFlightsClimbed?.doubleValue(
+                            for: HKUnit.count()
+                        ),
+                        "totalSwimmingStrokeCount": sample.totalSwimmingStrokeCount?.doubleValue(
+                            for: HKUnit.count()
+                        ),
+                        "duration": sample.duration,
                         "date_from": Int(sample.startDate.timeIntervalSince1970 * 1000),
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,
@@ -550,6 +557,13 @@ class HealthDataReader {
                         "totalEnergyBurnedUnit": "KILOCALORIE",
                         "totalDistance": sample.totalDistance?.doubleValue(for: HKUnit.meter()),
                         "totalDistanceUnit": "METER",
+                        "totalFlightsClimbed": sample.totalFlightsClimbed?.doubleValue(
+                            for: HKUnit.count()
+                        ),
+                        "totalSwimmingStrokeCount": sample.totalSwimmingStrokeCount?.doubleValue(
+                            for: HKUnit.count()
+                        ),
+                        "duration": sample.duration,
                         "date_from": Int(sample.startDate.timeIntervalSince1970 * 1000),
                         "date_to": Int(sample.endDate.timeIntervalSince1970 * 1000),
                         "source_id": sample.sourceRevision.source.bundleIdentifier,

--- a/lib/health.g.dart
+++ b/lib/health.g.dart
@@ -291,6 +291,9 @@ WorkoutHealthValue _$WorkoutHealthValueFromJson(Map<String, dynamic> json) =>
         _$HealthDataUnitEnumMap,
         json['totalStepsUnit'],
       ),
+      totalFlightsClimbed: (json['totalFlightsClimbed'] as num?)?.toInt(),
+      totalSwimmingStrokeCount: (json['totalSwimmingStrokeCount'] as num?)
+          ?.toInt(),
     )..$type = json['__type'] as String?;
 
 Map<String, dynamic> _$WorkoutHealthValueToJson(WorkoutHealthValue instance) =>
@@ -305,6 +308,8 @@ Map<String, dynamic> _$WorkoutHealthValueToJson(WorkoutHealthValue instance) =>
       'totalDistanceUnit': ?_$HealthDataUnitEnumMap[instance.totalDistanceUnit],
       'totalSteps': ?instance.totalSteps,
       'totalStepsUnit': ?_$HealthDataUnitEnumMap[instance.totalStepsUnit],
+      'totalFlightsClimbed': ?instance.totalFlightsClimbed,
+      'totalSwimmingStrokeCount': ?instance.totalSwimmingStrokeCount,
     };
 
 const _$HealthWorkoutActivityTypeEnumMap = {

--- a/lib/src/health_value_types.dart
+++ b/lib/src/health_value_types.dart
@@ -136,6 +136,14 @@ class WorkoutHealthValue extends HealthValue {
   /// Might not be available for all workouts.
   HealthDataUnit? totalStepsUnit;
 
+  /// The total number of flights of stairs climbed during the workout (iOS only).
+  /// Might not be available for all workouts.
+  int? totalFlightsClimbed;
+
+  /// The total number of swimming strokes during the workout (iOS only).
+  /// Might not be available for all workouts.
+  int? totalSwimmingStrokeCount;
+
   WorkoutHealthValue({
     required this.workoutActivityType,
     this.totalEnergyBurned,
@@ -144,6 +152,8 @@ class WorkoutHealthValue extends HealthValue {
     this.totalDistanceUnit,
     this.totalSteps,
     this.totalStepsUnit,
+    this.totalFlightsClimbed,
+    this.totalSwimmingStrokeCount,
   });
 
   /// Create a [WorkoutHealthValue] based on a health data point from native data format.
@@ -164,6 +174,9 @@ class WorkoutHealthValue extends HealthValue {
     totalStepsUnit: dataPoint['totalStepsUnit'] != null
         ? HealthDataUnit.values.firstWhere((element) => element.name == dataPoint['totalStepsUnit'])
         : null,
+    totalFlightsClimbed: dataPoint['totalFlightsClimbed'] != null ? (dataPoint['totalFlightsClimbed'] as num).toInt() : null,
+    totalSwimmingStrokeCount:
+        dataPoint['totalSwimmingStrokeCount'] != null ? (dataPoint['totalSwimmingStrokeCount'] as num).toInt() : null,
   );
 
   @override
@@ -181,7 +194,9 @@ class WorkoutHealthValue extends HealthValue {
            totalDistance: $totalDistance,
            totalDistanceUnit: ${totalDistanceUnit?.name}
            totalSteps: $totalSteps,
-           totalStepsUnit: ${totalStepsUnit?.name}""";
+           totalStepsUnit: ${totalStepsUnit?.name},
+           totalFlightsClimbed: $totalFlightsClimbed,
+           totalSwimmingStrokeCount: $totalSwimmingStrokeCount""";
 
   @override
   bool operator ==(Object other) =>
@@ -192,7 +207,9 @@ class WorkoutHealthValue extends HealthValue {
       totalDistance == other.totalDistance &&
       totalDistanceUnit == other.totalDistanceUnit &&
       totalSteps == other.totalSteps &&
-      totalStepsUnit == other.totalStepsUnit;
+      totalStepsUnit == other.totalStepsUnit &&
+      totalFlightsClimbed == other.totalFlightsClimbed &&
+      totalSwimmingStrokeCount == other.totalSwimmingStrokeCount;
 
   @override
   int get hashCode => Object.hash(
@@ -203,6 +220,8 @@ class WorkoutHealthValue extends HealthValue {
     totalDistanceUnit,
     totalSteps,
     totalStepsUnit,
+    totalFlightsClimbed,
+    totalSwimmingStrokeCount,
   );
 }
 


### PR DESCRIPTION
## Summary

Exposes two per-workout HealthKit totals that were not previously surfaced by the plugin:

- **Flights climbed** (`HKWorkout.totalFlightsClimbed`)
- **Swimming stroke count** (`HKWorkout.totalSwimmingStrokeCount`)

Both are direct `HKWorkout` properties. The workout's `duration` (seconds) is also added to the emitted dictionary for completeness.

## Changes

**iOS (`ios/Classes/HealthDataReader.swift`)** — both `[HKWorkout]` branches (the list read used by `getHealthDataFromTypes` and the single-sample read) now emit `totalFlightsClimbed`, `totalSwimmingStrokeCount` (in `HKUnit.count()`, null when the property is nil), and `duration`.

**Dart (`lib/src/health_value_types.dart`)** — `WorkoutHealthValue` gains nullable `int? totalFlightsClimbed` and `int? totalSwimmingStrokeCount` fields, parsed in `fromHealthDataPoint` mirroring `totalSteps`/`totalDistance`, and wired into the constructor, `toString`, `==`, and `hashCode`.

**Generated (`lib/health.g.dart`)** — regenerated via `dart run build_runner build` to include the new fields in JSON (de)serialization.

These are additive and nullable, so existing consumers are unaffected. Values are null on Android (HealthKit-only properties).