### PR TITLE
feat(ios): add getRequestStatusForAuthorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+* iOS: Add `getRequestStatusForAuthorization` to expose HealthKit's
+  `HKAuthorizationRequestStatus`. Unlike `hasPermissions` (which always returns
+  `null` for read types on iOS), this reports whether the authorization sheet
+  would still be shown, letting apps distinguish a first-time request from a
+  previously-answered one. Returns `null` on Android.
+
 ## 13.3.1
 
 * iOS: Fix issues with app crashing on iOS 15

--- a/ios/Classes/HealthDataOperations.swift
+++ b/ios/Classes/HealthDataOperations.swift
@@ -185,6 +185,88 @@ class HealthDataOperations {
         }
     }
 
+    /// Returns HealthKit's authorization *request* status for the given types.
+    ///
+    /// Mirrors `requestAuthorization`'s read/write set building, but calls
+    /// `getRequestStatusForAuthorization(toShare:read:)` instead of actually
+    /// requesting. The result is one of `"shouldRequest"`, `"unnecessary"` or
+    /// `"unknown"` — note this only reflects whether the authorization sheet
+    /// would be shown, not whether *read* access was granted (HealthKit never
+    /// exposes read-grant status).
+    func getRequestStatusForAuthorization(call: FlutterMethodCall, result: @escaping FlutterResult) throws {
+        guard let arguments = call.arguments as? NSDictionary,
+              let types = arguments["types"] as? [String],
+              let permissions = arguments["permissions"] as? [Int],
+              permissions.count == types.count
+        else {
+            throw PluginError(message: "Invalid Arguments!")
+        }
+
+        var typesToRead = Set<HKObjectType>()
+        var typesToWrite = Set<HKSampleType>()
+
+        for (index, key) in types.enumerated() {
+            let access = permissions[index]
+
+            if key == HealthConstants.NUTRITION {
+                for nutritionType in nutritionList {
+                    guard let nutritionData = dataTypesDict[nutritionType] else { continue }
+                    switch access {
+                    case 0:
+                        typesToRead.insert(nutritionData)
+                    case 1:
+                        typesToWrite.insert(nutritionData)
+                    default:
+                        typesToRead.insert(nutritionData)
+                        typesToWrite.insert(nutritionData)
+                    }
+                }
+                continue
+            }
+
+            if let dataType = dataTypesDict[key] {
+                switch access {
+                case 0:
+                    typesToRead.insert(dataType)
+                case 1:
+                    typesToWrite.insert(dataType)
+                default:
+                    typesToRead.insert(dataType)
+                    typesToWrite.insert(dataType)
+                }
+            }
+
+            // Characteristic types are read-only.
+            if let characteristicsType = characteristicsTypesDict[key] {
+                typesToRead.insert(characteristicsType)
+            }
+        }
+
+        healthStore.getRequestStatusForAuthorization(toShare: typesToWrite, read: typesToRead) {
+            status, error in
+            DispatchQueue.main.async {
+                if let error = error {
+                    result(FlutterError(code: "REQUEST_STATUS_ERROR",
+                                        message: error.localizedDescription,
+                                        details: nil))
+                    return
+                }
+                let value: String
+                switch status {
+                case .unknown:
+                    value = "unknown"
+                case .shouldRequest:
+                    value = "shouldRequest"
+                case .unnecessary:
+                    value = "unnecessary"
+                @unknown default:
+                    value = "unknown"
+                }
+                result(value)
+            }
+        }
+    }
+
     /// Delete health data by date range
     /// - Parameters:
     ///   - call: Flutter method call

--- a/ios/Classes/HealthDataOperations.swift
+++ b/ios/Classes/HealthDataOperations.swift
@@ -244,25 +244,25 @@ class HealthDataOperations {
 
         healthStore.getRequestStatusForAuthorization(toShare: typesToWrite, read: typesToRead) {
             status, error in
-            DispatchQueue.main.async {
-                if let error = error {
-                    result(FlutterError(code: "REQUEST_STATUS_ERROR",
+            let response: Any?
+            if let error = error {
+                response = FlutterError(code: "REQUEST_STATUS_ERROR",
                                         message: error.localizedDescription,
-                                        details: nil))
-                    return
-                }
-                let value: String
+                                        details: nil)
+            } else {
                 switch status {
                 case .unknown:
-                    value = "unknown"
+                    response = "unknown"
                 case .shouldRequest:
-                    value = "shouldRequest"
+                    response = "shouldRequest"
                 case .unnecessary:
-                    value = "unnecessary"
+                    response = "unnecessary"
                 @unknown default:
-                    value = "unknown"
+                    response = "unknown"
                 }
-                result(value)
+            }
+            Task { @MainActor in
+                result(response)
             }
         }
     }

--- a/ios/Classes/SwiftHealthPlugin.swift
+++ b/ios/Classes/SwiftHealthPlugin.swift
@@ -163,6 +163,15 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
                                     details: nil))
             }
 
+        case "getRequestStatusForAuthorization":
+            do {
+                try healthDataOperations.getRequestStatusForAuthorization(call: call, result: result)
+            } catch {
+                result(FlutterError(code: "PERMISSION_ERROR",
+                                    message: "Error getting request status: \(error.localizedDescription)",
+                                    details: nil))
+            }
+
         case "delete":
             do {
                 healthDataOperations.delete(call: call, result: result)

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -44,3 +44,35 @@ enum HealthConnectSdkStatus {
     );
   }
 }
+
+/// The status returned by [Health.getRequestStatusForAuthorization].
+///
+/// Mirrors Apple's
+/// [`HKAuthorizationRequestStatus`](https://developer.apple.com/documentation/healthkit/hkauthorizationrequeststatus).
+///
+/// This indicates whether the authorization sheet would still be shown for the
+/// requested types — it does **not** reveal whether *read* access was actually
+/// granted, which HealthKit never exposes to apps.
+enum HealthAuthorizationRequestStatus {
+  /// It is unknown whether the app should request authorization (e.g. an error
+  /// occurred while determining the status).
+  unknown,
+
+  /// The app should request authorization: at least one of the requested types
+  /// has not been presented to the user yet.
+  shouldRequest,
+
+  /// Requesting authorization is unnecessary: the user has already been
+  /// presented with the authorization sheet for all requested types.
+  unnecessary;
+
+  /// Maps the native string value (from the platform channel) to an enum value.
+  static HealthAuthorizationRequestStatus? fromString(String? value) {
+    return switch (value) {
+      'shouldRequest' => HealthAuthorizationRequestStatus.shouldRequest,
+      'unnecessary' => HealthAuthorizationRequestStatus.unnecessary,
+      'unknown' => HealthAuthorizationRequestStatus.unknown,
+      _ => null,
+    };
+  }
+}

--- a/lib/src/health_plugin.dart
+++ b/lib/src/health_plugin.dart
@@ -404,6 +404,47 @@ class Health {
     return isAuthorized ?? false;
   }
 
+  /// Returns whether the app still needs to request authorization for the
+  /// given [types] (Apple's
+  /// [`getRequestStatusForAuthorization`](https://developer.apple.com/documentation/healthkit/hkhealthstore/2994346-getrequeststatusforauthorization)).
+  ///
+  /// Unlike [hasPermissions] — which always returns `null` for *read* types on
+  /// iOS — this reports whether the authorization sheet would still be shown
+  /// ([HealthAuthorizationRequestStatus.shouldRequest]) or not
+  /// ([HealthAuthorizationRequestStatus.unnecessary]). It does **not** reveal
+  /// whether read access was actually granted; HealthKit never exposes that.
+  /// This is therefore useful to decide whether to show a first-time request
+  /// flow versus guiding the user to the Health app to change an existing
+  /// decision.
+  ///
+  /// The optional [permissions] must, if provided, match the length of [types]
+  /// (see [HealthDataAccess]). When omitted, read access is assumed for all
+  /// types.
+  ///
+  /// iOS only. Returns `null` on Android (use [hasPermissions] there) and if
+  /// the status cannot be determined.
+  Future<HealthAuthorizationRequestStatus?> getRequestStatusForAuthorization(
+    List<HealthDataType> types, {
+    List<HealthDataAccess>? permissions,
+  }) async {
+    if (permissions != null && permissions.length != types.length) {
+      throw ArgumentError('The length of [types] must be same as that of [permissions].');
+    }
+
+    if (!Platform.isIOS) return null;
+
+    final mPermissions = permissions == null
+        ? List<int>.filled(types.length, HealthDataAccess.READ.index, growable: false)
+        : permissions.map((permission) => permission.index).toList();
+
+    final keys = types.map((e) => e.name).toList();
+    final value = await _channel.invokeMethod<String>('getRequestStatusForAuthorization', {
+      'types': keys,
+      'permissions': mPermissions,
+    });
+    return HealthAuthorizationRequestStatus.fromString(value);
+  }
+
   /// Obtains health and weight if BMI is requested on Android.
   void _handleBMI(List<HealthDataType> mTypes, List<int> mPermissions) {
     final index = mTypes.indexOf(HealthDataType.BODY_MASS_INDEX);
@@ -1241,10 +1282,7 @@ class Health {
   /// Fetch the next page of changes for a previously created token.
   ///
   /// Android only. Returns null on iOS or if an error occurs.
-  Future<HealthChangesResponse?> getChanges({
-    required String changesToken,
-    bool includeSelf = false,
-  }) async {
+  Future<HealthChangesResponse?> getChanges({required String changesToken, bool includeSelf = false}) async {
     if (Platform.isIOS) return null;
 
     await _checkIfHealthConnectAvailableOnAndroid();

--- a/test/unit/health_plugin_request_status_test.dart
+++ b/test/unit/health_plugin_request_status_test.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:health/health.dart';
+
+import '../support/health_test_context.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late HealthTestContext ctx;
+
+  setUp(() async {
+    ctx = HealthTestContext();
+    await ctx.setUp();
+  });
+
+  tearDown(() async {
+    await ctx.tearDown();
+  });
+
+  group('getRequestStatusForAuthorization', () {
+    test('throws when permissions length mismatches types', () {
+      expect(
+        () => ctx.health.getRequestStatusForAuthorization(
+          [HealthDataType.HEART_RATE],
+          permissions: [HealthDataAccess.READ, HealthDataAccess.WRITE],
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('returns null on non-iOS without invoking the channel', () async {
+      final status = await ctx.health.getRequestStatusForAuthorization([HealthDataType.STEPS]);
+
+      expect(status, isNull);
+      expect(ctx.channel.lastCallFor('getRequestStatusForAuthorization'), isNull);
+    }, skip: Platform.isIOS ? 'iOS forwards to the channel' : false);
+
+    test('iOS: forwards types/permissions and maps the result', () async {
+      ctx.channel.when('getRequestStatusForAuthorization', 'unnecessary');
+
+      final status = await ctx.health.getRequestStatusForAuthorization([HealthDataType.STEPS, HealthDataType.WEIGHT]);
+
+      expect(status, HealthAuthorizationRequestStatus.unnecessary);
+      final call = ctx.channel.lastCallFor('getRequestStatusForAuthorization');
+      expect(call, isNotNull);
+      final args = Map<String, dynamic>.from(call!.arguments as Map);
+      expect(args['types'], [HealthDataType.STEPS.name, HealthDataType.WEIGHT.name]);
+      expect(args['permissions'], [HealthDataAccess.READ.index, HealthDataAccess.READ.index]);
+    }, skip: Platform.isIOS ? false : 'channel path only runs on iOS');
+
+    test('iOS: maps shouldRequest and unknown', () async {
+      ctx.channel.when('getRequestStatusForAuthorization', 'shouldRequest');
+      expect(
+        await ctx.health.getRequestStatusForAuthorization([HealthDataType.STEPS]),
+        HealthAuthorizationRequestStatus.shouldRequest,
+      );
+
+      ctx.channel.when('getRequestStatusForAuthorization', 'unknown');
+      expect(
+        await ctx.health.getRequestStatusForAuthorization([HealthDataType.STEPS]),
+        HealthAuthorizationRequestStatus.unknown,
+      );
+    }, skip: Platform.isIOS ? false : 'channel path only runs on iOS');
+  });
+
+  group('HealthAuthorizationRequestStatus.fromString', () {
+    test('maps known values and falls back to null', () {
+      expect(
+        HealthAuthorizationRequestStatus.fromString('shouldRequest'),
+        HealthAuthorizationRequestStatus.shouldRequest,
+      );
+      expect(HealthAuthorizationRequestStatus.fromString('unnecessary'), HealthAuthorizationRequestStatus.unnecessary);
+      expect(HealthAuthorizationRequestStatus.fromString('unknown'), HealthAuthorizationRequestStatus.unknown);
+      expect(HealthAuthorizationRequestStatus.fromString(null), isNull);
+      expect(HealthAuthorizationRequestStatus.fromString('bogus'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Motivation

On iOS, `hasPermissions` always returns `null` for **read** types because
HealthKit deliberately does not expose read-authorization status to apps
(see #939 and many related reports). As a result, apps cannot tell a
*first-time* authorization request from one the user has *already answered*,
which makes it impossible to branch permission UX correctly (e.g. show a
request flow vs. guide the user to the Health app to change an existing
decision).

HealthKit exposes exactly this signal via
[`HKHealthStore.getRequestStatusForAuthorization(toShare:read:)`](https://developer.apple.com/documentation/healthkit/hkhealthstore/2994346-getrequeststatusforauthorization),
but the plugin doesn't surface it. This PR adds a thin wrapper.

## What's new

- **Dart**: `Health.getRequestStatusForAuthorization(List<HealthDataType> types, {List<HealthDataAccess>? permissions})`
  returning a new `HealthAuthorizationRequestStatus` enum
  (`shouldRequest` / `unnecessary` / `unknown`). Returns `null` on Android.
- **iOS**: new `getRequestStatusForAuthorization` method-channel handler in
  `HealthDataOperations`, mirroring `requestAuthorization`'s read/write set
  building, then calling `getRequestStatusForAuthorization(toShare:read:)` and
  mapping `HKAuthorizationRequestStatus`.
- **Tests**: argument validation, the non-iOS `null` path, channel forwarding
  and enum mapping.
- CHANGELOG entry.

## Important caveat (documented in the API)

This reports whether the **authorization sheet would still be shown**, not
whether **read access was granted** — HealthKit never exposes read-grant
status. The dartdoc states this explicitly so callers don't misuse it as a
"is read allowed?" check.

## Backward compatibility

Purely additive. No existing API changes. Android behaviour is a no-op
(`null`), guarded on the Dart side so no platform channel call is made there.
