### PR TITLE
fix!: return record IDs from writeWorkoutData so workout routes can be attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## NEXT (breaking)
+
+* BREAKING: `writeWorkoutData` now returns `Future<List<String>>` - the
+  platform record IDs of the inserted records (iOS: the `HKWorkout` UUID;
+  Health Connect: exercise session record ID first) - instead of
+  `Future<bool>`, and surfaces platform write failures as `PlatformException`
+  instead of `false`. The first returned ID is the `workoutUuid` that
+  `finishWorkoutRoute` requires; without it, workout routes (added in
+  13.3.0) could never be attached. Migration: replace `success =
+  await writeWorkoutData(...)` with `ids = await writeWorkoutData(...)`
+  and treat a non-empty list / absence of an exception as success.
+
 ## 13.3.1
 
 * iOS: Fix issues with app crashing on iOS 15

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataWriter.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataWriter.kt
@@ -288,8 +288,13 @@ class HealthDataWriter(
                     )
                 }
 
-                healthConnectClient.insertRecords(list)
-                result.success(true)
+                // Return the inserted record IDs (exercise session first)
+                // so callers can attach a route to the session via
+                // finishWorkoutRoute. Discarding them made route attachment
+                // impossible: finishWorkoutRoute needs the session's record
+                // ID, which only this insert response ever exposes.
+                val response = healthConnectClient.insertRecords(list)
+                result.success(response.recordIdsList)
                 Log.i("FLUTTER_HEALTH::SUCCESS", "[Health Connect] Workout was successfully added!")
             } catch (e: Exception) {
                 Log.w(
@@ -298,7 +303,11 @@ class HealthDataWriter(
                 )
                 Log.w("FLUTTER_HEALTH::ERROR", e.message ?: "unknown error")
                 Log.w("FLUTTER_HEALTH::ERROR", e.stackTrace.toString())
-                result.success(false)
+                result.error(
+                        "WRITE_WORKOUT_ERROR",
+                        "[Health Connect] There was an error adding the workout",
+                        e.message ?: "unknown error"
+                )
             }
         }
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -555,14 +555,15 @@ class HealthAppState extends State<HealthApp> {
       startTime: earlier,
       endTime: now,
     );
-    success &= await health.writeWorkoutData(
+    success &= (await health.writeWorkoutData(
       activityType: HealthWorkoutActivityType.AMERICAN_FOOTBALL,
       title: "Random workout name that shows up in Health Connect",
       start: now.subtract(const Duration(minutes: 15)),
       end: now,
       totalDistance: 2430,
       totalEnergyBurned: 400,
-    );
+    ))
+        .isNotEmpty;
     success &= await health.writeBloodPressure(
       systolic: 90,
       diastolic: 80,

--- a/ios/Classes/HealthDataWriter.swift
+++ b/ios/Classes/HealthDataWriter.swift
@@ -883,7 +883,22 @@ class HealthDataWriter {
                     print("Error Saving Workout. Sample: \(err.localizedDescription)")
                 }
                 DispatchQueue.main.async {
-                    result(success)
+                    // Return the saved workout's UUID so callers can attach
+                    // a route to it via finishWorkoutRoute. Discarding it made
+                    // route attachment impossible: the route builder's
+                    // HKSampleQuery needs this UUID, which only the save
+                    // callback ever exposes.
+                    if success {
+                        result([workout.uuid.uuidString])
+                    } else {
+                        result(
+                            FlutterError(
+                                code: "WRITE_WORKOUT_FAILED",
+                                message: "HealthKit save returned false for workout.",
+                                details: nil
+                            )
+                        )
+                    }
                 }
             }
         )

--- a/lib/src/health_plugin.dart
+++ b/lib/src/health_plugin.dart
@@ -1494,7 +1494,15 @@ class Health {
 
   /// Write workout data to Apple Health or Google Health Connect.
   ///
-  /// Returns true if the workout data was successfully added.
+  /// Returns the platform record IDs of the inserted records. On iOS this
+  /// is a single-element list with the HKWorkout UUID; on Health Connect
+  /// the exercise session record ID comes first, followed by the optional
+  /// distance and energy records. The first element is what
+  /// [finishWorkoutRoute] needs as its `workoutUuid`. Throws on platform
+  /// failure.
+  ///
+  /// Breaking change: previously returned `Future<bool>` and swallowed
+  /// platform errors as `false`.
   ///
   /// Parameters:
   ///  - [activityType] The type of activity performed.
@@ -1509,7 +1517,7 @@ class Health {
   ///  - [title] The title of the workout.
   ///    *ONLY FOR HEALTH CONNECT* Default value is the [activityType], e.g. "STRENGTH_TRAINING".
   ///  - [recordingMethod] The recording method of the data point, automatic by default (on iOS this can only be automatic or manual).
-  Future<bool> writeWorkoutData({
+  Future<List<String>> writeWorkoutData({
     required HealthWorkoutActivityType activityType,
     required DateTime start,
     required DateTime end,
@@ -1542,7 +1550,8 @@ class Health {
       'title': title,
       'recordingMethod': recordingMethod.toInt(),
     };
-    return await _channel.invokeMethod('writeWorkoutData', args) == true;
+    final response = await _channel.invokeMethod('writeWorkoutData', args);
+    return response is List ? response.cast<String>() : <String>[];
   }
 
   /// Start a new workout route recording session on iOS or Android.

--- a/test/support/stub_device_info.dart
+++ b/test/support/stub_device_info.dart
@@ -64,6 +64,7 @@ class StubDeviceInfoPlugin implements DeviceInfoPlugin {
           'physicalRamSize': 8192,
           'availableRamSize': 4096,
           'isiOSAppOnMac': false,
+          'isiOSAppOnVision': false,
           'utsname': {
             'sysname': 'stub-ios-sysname',
             'nodename': 'stub-ios-nodename',

--- a/test/unit/health_plugin_writes_test.dart
+++ b/test/unit/health_plugin_writes_test.dart
@@ -201,7 +201,9 @@ void main() {
         expect(args['value'], MenstrualFlow.medium.index);
         expect(args['isStartOfCycle'], isTrue);
       },
-      skip: Platform.isAndroid ? 'Android uses Health Connect value mapping' : null,
+      skip: Platform.isAndroid
+          ? 'Android uses Health Connect value mapping'
+          : null,
     );
   });
 
@@ -287,7 +289,9 @@ void main() {
         expect(args['units'], 3);
         expect(args['reason'], InsulinDeliveryReason.BOLUS.index);
       },
-      skip: Platform.isAndroid ? 'Insulin delivery unsupported on Android' : null,
+      skip: Platform.isAndroid
+          ? 'Insulin delivery unsupported on Android'
+          : null,
     );
   });
 
@@ -381,7 +385,9 @@ void main() {
       expect(call, isNotNull);
       final args = Map<String, dynamic>.from(call!.arguments as Map);
       final rawLocations = List<dynamic>.from(args['locations'] as List);
-      final locations = rawLocations.map((entry) => Map<String, dynamic>.from(entry as Map)).toList();
+      final locations = rawLocations
+          .map((entry) => Map<String, dynamic>.from(entry as Map))
+          .toList();
       expect(locations, hasLength(1));
       expect(locations.first['latitude'], 37.3349);
       expect(locations.first['horizontalAccuracy'], 5);
@@ -416,5 +422,66 @@ void main() {
       final args = Map<String, dynamic>.from(call!.arguments as Map);
       expect(args['builderId'], 'builder-1');
     });
+  });
+
+  group('writeWorkoutData', () {
+    test('returns the platform record IDs from the channel', () async {
+      ctx.channel.when('writeWorkoutData', [
+        'session-record-id',
+        'distance-record-id',
+        'energy-record-id',
+      ]);
+
+      final ids = await ctx.health.writeWorkoutData(
+        activityType: HealthWorkoutActivityType.BIKING,
+        start: DateTime(2026, 6, 1, 10),
+        end: DateTime(2026, 6, 1, 11),
+        totalDistance: 25000,
+        totalEnergyBurned: 600,
+      );
+
+      expect(ids, [
+        'session-record-id',
+        'distance-record-id',
+        'energy-record-id',
+      ]);
+
+      final call = ctx.channel.lastCallFor('writeWorkoutData');
+      expect(call, isNotNull);
+      final args = call!.arguments as Map;
+      expect(args['activityType'], 'BIKING');
+      expect(args['totalDistance'], 25000);
+      expect(args['totalEnergyBurned'], 600);
+    });
+
+    test(
+      'returns an empty list when the channel response is not a list',
+      () async {
+        ctx.channel.when('writeWorkoutData', true);
+
+        final ids = await ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.BIKING,
+          start: DateTime(2026, 6, 1, 10),
+          end: DateTime(2026, 6, 1, 11),
+        );
+
+        expect(ids, isEmpty);
+      },
+    );
+
+    test(
+      'first returned ID is usable as the finishWorkoutRoute workout UUID',
+      () async {
+        ctx.channel.when('writeWorkoutData', ['workout-uuid']);
+
+        final ids = await ctx.health.writeWorkoutData(
+          activityType: HealthWorkoutActivityType.BIKING,
+          start: DateTime(2026, 6, 1, 10),
+          end: DateTime(2026, 6, 1, 11),
+        );
+
+        expect(ids.first, 'workout-uuid');
+      },
+    );
   });
 }


### PR DESCRIPTION
## Motivation

`finishWorkoutRoute` (added with `WORKOUT_ROUTE` support in 13.3.0, PR #454) needs the workout's platform identifier: on iOS its `HKSampleQuery` matches the workout UUID, and on Health Connect `readRecord` needs the exercise-session record ID. But `writeWorkoutData` discards exactly those IDs and returns a bare `bool`, so the lookup can never match - **workout routes can never be attached on either platform**. Every route write fails with "Workout with UUID ... not found".

## Fix

Return the platform record IDs from `writeWorkoutData`:

- **iOS**: a single-element list containing the saved `HKWorkout` UUID. HealthKit save failures now surface as a `FlutterError` instead of `false`.
- **Android**: `insertRecords(...).recordIdsList` (exercise session record first, then the optional distance / energy records). Health Connect failures now surface via `result.error`.
- **Dart**: `writeWorkoutData` returns `Future<List<String>>`. The first element is the `workoutUuid` that `finishWorkoutRoute` requires.

```dart
final ids = await health.writeWorkoutData(activityType: ..., start: ..., end: ...);
await health.startWorkoutRoute(...);
// ... add route points ...
await health.finishWorkoutRoute(workoutUuid: ids.first, ...);
```

## Breaking change

`Future<bool>` -> `Future<List<String>>`, and platform write failures throw `PlatformException` instead of returning `false`. Migration: treat a non-empty list / absence of an exception as success. CHANGELOG entry included under a "NEXT (breaking)" heading - happy to re-slot it under whatever version number you plan.

If you'd prefer a non-breaking shape (e.g. a new `writeWorkoutDataWithRecordIds` method, leaving `writeWorkoutData` as-is), say the word and I'll rework this PR.

## Tests

Added a `writeWorkoutData` group to `test/unit/health_plugin_writes_test.dart` (return shape, non-list fallback, first-ID-is-route-uuid) using the existing `HealthTestContext` harness. Note: the unit suite currently fails on a fresh checkout of `main` because the iOS device-info stub predates `device_info_plus` 12.4 (`isiOSAppOnVision` missing); this PR includes the one-line stub fix so the suite runs green (27/27 locally). I see #485 also touches the stub - happy to rebase over it if it lands first (this PR will conflict textually with #485 in `writeWorkoutData` either way; the changes are compatible in spirit).

## Production validation

This exact patch has been running in production in [Party Onbici](https://apps.apple.com/app/id6751864052) (cycling app, iOS + Android) since June 2026 via a pinned fork, exporting cycling workouts with GPS routes to both Apple Health and Health Connect. Routes attach reliably on both platforms with this change; with stock 13.3.1 they never attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #482