### PR TITLE
Bump device_info_plus to ^13.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   intl: '>=0.18.0 <0.21.0'
-  device_info_plus: '^12.1.0'
+  device_info_plus: ^13.1.0
   json_annotation: ^4.9.0
   carp_serializable: ^2.0.1 # polymorphic json serialization
 


### PR DESCRIPTION
## Summary

Bumps the `device_info_plus` constraint from `^12.1.0` to `^13.1.0`.

Fixes #502.

The previous `^12.1.0` constraint excluded `device_info_plus` 13.x. Apps depending on `device_info_plus ^13.0.0` could not resolve `health >=13.2.0`, causing version solving to fail and forcing pub to downgrade `health` all the way to 3.0.6.

## Test plan

- [ ] `flutter pub get` resolves cleanly with `device_info_plus 13.x`
