### PR TITLE
Handle Health Connect service failures without crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Android: Prevent Health Connect Binder and service-binding failures from crashing the host app.
+
 ## 13.3.1
 
 * iOS: Fix issues with app crashing on iOS 15

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,6 +47,9 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
     namespace "cachet.plugins.health"
 }
 
@@ -57,5 +60,6 @@ dependencies {
 
     implementation("androidx.health.connect:connect-client:1.2.0-alpha02")
     implementation "androidx.fragment:fragment-ktx:1.8.9"
+    testImplementation "junit:junit:4.13.2"
 
 }

--- a/android/src/main/kotlin/cachet/plugins/health/HealthConnectOperation.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthConnectOperation.kt
@@ -1,0 +1,100 @@
+package cachet.plugins.health
+
+import android.os.DeadObjectException
+import android.os.RemoteException
+import android.util.Log
+import io.flutter.plugin.common.MethodChannel.Result
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+/**
+ * Guarantees that a method-channel call is completed at most once.
+ *
+ * Health Connect callbacks can race with activity/engine detachment and Binder death. Flutter
+ * rejects duplicate replies, so all native handlers receive this wrapper at the dispatch boundary.
+ */
+internal class GuardedResult(
+        private val delegate: Result,
+        private val operation: String,
+) : Result {
+    private val completed = AtomicBoolean(false)
+
+    override fun success(result: Any?) = complete { delegate.success(result) }
+
+    override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) =
+            complete { delegate.error(errorCode, errorMessage, errorDetails) }
+
+    override fun notImplemented() = complete { delegate.notImplemented() }
+
+    private inline fun complete(reply: () -> Unit) {
+        if (completed.compareAndSet(false, true)) {
+            try {
+                reply()
+            } catch (exception: Exception) {
+                Log.w(TAG, "Unable to deliver result for $operation", exception)
+            }
+        } else {
+            Log.w(TAG, "Ignoring duplicate result for $operation")
+        }
+    }
+
+    private companion object {
+        const val TAG = "FLUTTER_HEALTH"
+    }
+}
+
+/** Runs one suspending Health Connect operation and converts every expected failure to Flutter. */
+internal fun CoroutineScope.launchHealthConnectOperation(
+        operation: String,
+        result: Result,
+        block: suspend () -> Any?,
+): Job =
+        launch {
+            try {
+                result.success(block())
+            } catch (exception: CancellationException) {
+                result.failHealthConnect(operation, exception)
+            } catch (exception: Exception) {
+                result.failHealthConnect(operation, exception)
+            }
+        }
+
+/** Maps native failures to stable, non-sensitive method-channel errors. */
+internal fun Result.failHealthConnect(operation: String, exception: Throwable) {
+    val errorCode = healthConnectErrorCode(exception)
+    Log.e(TAG, "$operation failed ($errorCode)", exception)
+    error(
+            errorCode,
+            exception.message ?: exception.javaClass.simpleName,
+            mapOf(
+                    "operation" to operation,
+                    "exception" to exception.javaClass.name,
+            ),
+    )
+}
+
+internal fun healthConnectErrorCode(exception: Throwable): String {
+    val causes = generateSequence(exception) { it.cause }.take(10).toList()
+    val message = causes.joinToString(" ") { it.message.orEmpty() }.lowercase()
+    return when {
+        causes.any { it is DeadObjectException } || "binder died" in message ->
+                "health_connect_binder_died"
+        "binding died" in message -> "health_connect_binding_died"
+        "null binding" in message -> "health_connect_null_binding"
+        "binding to service failed" in message -> "health_connect_bind_failed"
+        causes.any { it is RemoteException } -> "health_connect_remote_error"
+        causes.any { it is SecurityException } -> "health_connect_security_error"
+        causes.any { it is IOException } -> "health_connect_io_error"
+        causes.any { it is CancellationException } -> "health_connect_cancelled"
+        causes.any { it is IllegalArgumentException } -> "health_connect_invalid_argument"
+        causes.any { it is IllegalStateException } -> "health_connect_invalid_state"
+        causes.any { it is UnsupportedOperationException } -> "health_connect_unsupported"
+        else -> "health_connect_unknown_error"
+    }
+}
+
+private const val TAG = "FLUTTER_HEALTH"

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataOperations.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataOperations.kt
@@ -54,13 +54,8 @@ class HealthDataOperations(
             return
         }
 
-        scope.launch {
-            result.success(
-                    healthConnectClient
-                            .permissionController
-                            .getGrantedPermissions()
-                            .containsAll(permList),
-            )
+        scope.launchHealthConnectOperation("hasPermissions", result) {
+            healthConnectClient.permissionController.getGrantedPermissions().containsAll(permList)
         }
     }
 
@@ -89,11 +84,11 @@ class HealthDataOperations(
      * @param result Flutter result callback returning success status
      */
     fun revokePermissions(call: MethodCall, result: Result) {
-        scope.launch {
+        scope.launchHealthConnectOperation("revokePermissions", result) {
             Log.i("FLUTTER_HEALTH", "Revoking all Health Connect permissions")
             healthConnectClient.permissionController.revokeAllPermissions()
+            true
         }
-        result.success(true)
     }
 
     /**
@@ -104,12 +99,10 @@ class HealthDataOperations(
      * @param result Flutter result callback returning boolean availability status
      */
     fun isHealthDataHistoryAvailable(call: MethodCall, result: Result) {
-        scope.launch {
-            result.success(
-                    healthConnectClient.features.getFeatureStatus(
-                            HealthConnectFeatures.FEATURE_READ_HEALTH_DATA_HISTORY
-                    ) == HealthConnectFeatures.FEATURE_STATUS_AVAILABLE
-            )
+        scope.launchHealthConnectOperation("isHealthDataHistoryAvailable", result) {
+            healthConnectClient.features.getFeatureStatus(
+                    HealthConnectFeatures.FEATURE_READ_HEALTH_DATA_HISTORY
+            ) == HealthConnectFeatures.FEATURE_STATUS_AVAILABLE
         }
     }
 
@@ -121,13 +114,10 @@ class HealthDataOperations(
      * @param result Flutter result callback returning boolean authorization status
      */
     fun isHealthDataHistoryAuthorized(call: MethodCall, result: Result) {
-        scope.launch {
-            result.success(
-                    healthConnectClient
-                            .permissionController
-                            .getGrantedPermissions()
-                            .containsAll(listOf(PERMISSION_READ_HEALTH_DATA_HISTORY)),
-            )
+        scope.launchHealthConnectOperation("isHealthDataHistoryAuthorized", result) {
+            healthConnectClient.permissionController
+                    .getGrantedPermissions()
+                    .containsAll(listOf(PERMISSION_READ_HEALTH_DATA_HISTORY))
         }
     }
 
@@ -139,12 +129,10 @@ class HealthDataOperations(
      * @param result Flutter result callback returning boolean availability status
      */
     fun isHealthDataInBackgroundAvailable(call: MethodCall, result: Result) {
-        scope.launch {
-            result.success(
-                    healthConnectClient.features.getFeatureStatus(
-                            HealthConnectFeatures.FEATURE_READ_HEALTH_DATA_IN_BACKGROUND
-                    ) == HealthConnectFeatures.FEATURE_STATUS_AVAILABLE
-            )
+        scope.launchHealthConnectOperation("isHealthDataInBackgroundAvailable", result) {
+            healthConnectClient.features.getFeatureStatus(
+                    HealthConnectFeatures.FEATURE_READ_HEALTH_DATA_IN_BACKGROUND
+            ) == HealthConnectFeatures.FEATURE_STATUS_AVAILABLE
         }
     }
 
@@ -156,13 +144,10 @@ class HealthDataOperations(
      * @param result Flutter result callback returning boolean authorization status
      */
     fun isHealthDataInBackgroundAuthorized(call: MethodCall, result: Result) {
-        scope.launch {
-            result.success(
-                    healthConnectClient
-                            .permissionController
-                            .getGrantedPermissions()
-                            .containsAll(listOf(PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND)),
-            )
+        scope.launchHealthConnectOperation("isHealthDataInBackgroundAuthorized", result) {
+            healthConnectClient.permissionController
+                    .getGrantedPermissions()
+                    .containsAll(listOf(PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND))
         }
     }
 
@@ -174,12 +159,10 @@ class HealthDataOperations(
      * @param result Flutter result callback returning boolean availability status
      */
     fun isSkinTemperatureAvailable(call: MethodCall, result: Result) {
-        scope.launch {
-            result.success(
-                    healthConnectClient.features.getFeatureStatus(
-                            HealthConnectFeatures.FEATURE_SKIN_TEMPERATURE
-                    ) == HealthConnectFeatures.FEATURE_STATUS_AVAILABLE
-            )
+        scope.launchHealthConnectOperation("isSkinTemperatureAvailable", result) {
+            healthConnectClient.features.getFeatureStatus(
+                    HealthConnectFeatures.FEATURE_SKIN_TEMPERATURE
+            ) == HealthConnectFeatures.FEATURE_STATUS_AVAILABLE
         }
     }
 

--- a/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -62,17 +62,23 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
     override fun onAttachedToEngine(
             @NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding
     ) {
-        scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+        val exceptionHandler = CoroutineExceptionHandler { _, exception ->
+            // Per-operation handlers complete their own Flutter result. This is the final safety
+            // net for any future coroutine added without an operation boundary.
+            Log.e("FLUTTER_HEALTH", "Unhandled Health Connect coroutine failure", exception)
+        }
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Main + exceptionHandler)
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, CHANNEL_NAME)
         channel?.setMethodCallHandler(this)
         context = flutterPluginBinding.applicationContext
         handler = Handler(context!!.mainLooper)
 
-        checkAvailability()
-        if (healthConnectAvailable) {
-            healthConnectClient =
-                    HealthConnectClient.getOrCreate(flutterPluginBinding.applicationContext)
-            initializeHelpers()
+        try {
+            initializeClientIfAvailable()
+        } catch (exception: Exception) {
+            healthConnectAvailable = false
+            healthConnectStatus = HealthConnectClient.SDK_UNAVAILABLE
+            Log.e("FLUTTER_HEALTH", "Health Connect initialization failed", exception)
         }
     }
 
@@ -83,9 +89,18 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
      * @param binding Plugin binding (unused in cleanup)
      */
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        failPendingAuthorization(
+                "health_connect_engine_detached",
+                "Flutter engine detached during Health Connect authorization",
+        )
         channel = null
         activity = null
-        scope.cancel()
+        healthConnectRequestPermissionsLauncher = null
+        if (this::scope.isInitialized) {
+            scope.cancel()
+        }
+        handler = null
+        context = null
     }
 
     override fun success(p0: Any?) {
@@ -117,18 +132,66 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
      * @param result Result callback to return data or status to Flutter
      */
     override fun onMethodCall(call: MethodCall, result: Result) {
-        when (call.method) {
-            // SDK and Installation
-            "installHealthConnect" -> installHealthConnect(call, result)
-            "getHealthConnectSdkStatus" -> {
-                checkAvailability()
-                if (healthConnectAvailable && !(this::dataOperations.isInitialized)) {
-                    healthConnectClient = HealthConnectClient.getOrCreate(context!!)
-                    initializeHelpers()
+        val guardedResult = GuardedResult(result, call.method)
+        try {
+            when (call.method) {
+                "installHealthConnect" -> installHealthConnect(call, guardedResult)
+                "getHealthConnectSdkStatus" -> {
+                    initializeClientIfAvailable()
+                    guardedResult.success(healthConnectStatus)
                 }
-                result.success(healthConnectStatus)
+                else -> {
+                    if (!isHealthConnectMethod(call.method)) {
+                        guardedResult.notImplemented()
+                        return
+                    }
+                    if (!ensureHealthConnectReady(guardedResult)) return
+                    dispatchHealthConnectCall(call, guardedResult)
+                }
+            }
+        } catch (exception: Exception) {
+            guardedResult.failHealthConnect(call.method, exception)
+        }
+    }
+
+    private fun isHealthConnectMethod(method: String): Boolean =
+            when (method) {
+                "hasPermissions",
+                "requestAuthorization",
+                "revokePermissions",
+                "isHealthDataHistoryAvailable",
+                "isHealthDataHistoryAuthorized",
+                "requestHealthDataHistoryAuthorization",
+                "isHealthDataInBackgroundAvailable",
+                "isHealthDataInBackgroundAuthorized",
+                "requestHealthDataInBackgroundAuthorization",
+                "isSkinTemperatureAvailable",
+                "getData",
+                "getDataByUUID",
+                "getIntervalData",
+                "getAggregateData",
+                "getTotalStepsInInterval",
+                "getChangesToken",
+                "getChanges",
+                "writeData",
+                "writeWorkoutData",
+                "writeBloodPressure",
+                "writeBloodOxygen",
+                "writeMenstruationFlow",
+                "writeMeal",
+                "writeActivityIntensity",
+                "startWorkoutRoute",
+                "insertWorkoutRouteData",
+                "finishWorkoutRoute",
+                "discardWorkoutRoute",
+                "delete",
+                "deleteByUUID",
+                "deleteByClientRecordId" -> true
+                else -> false
             }
 
+    private fun dispatchHealthConnectCall(call: MethodCall, result: Result) {
+        when (call.method) {
             // Permissions
             "hasPermissions" -> dataOperations.hasPermissions(call, result)
             "requestAuthorization" -> requestAuthorization(call, result)
@@ -173,8 +236,6 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
             "insertWorkoutRouteData" -> dataWriter.insertWorkoutRouteData(call, result)
             "finishWorkoutRoute" -> dataWriter.finishWorkoutRoute(call, result)
             "discardWorkoutRoute" -> dataWriter.discardWorkoutRoute(call, result)
-            // TODO: Add support for multiple speed for iOS as well
-            // "writeMultipleSpeed" -> dataWriter.writeMultipleSpeedData(call, result)
 
             // Deleting data
             "delete" -> dataOperations.deleteData(call, result)
@@ -197,13 +258,25 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
         binding.addActivityResultListener(this)
         activity = binding.activity
 
-        val requestPermissionActivityContract =
-                PermissionController.createRequestPermissionResultContract()
+        val componentActivity = activity as? ComponentActivity
+        if (componentActivity == null) {
+            Log.e("FLUTTER_HEALTH", "Permission requests require a ComponentActivity")
+            healthConnectRequestPermissionsLauncher = null
+            return
+        }
 
-        healthConnectRequestPermissionsLauncher =
-                (activity as ComponentActivity).registerForActivityResult(
-                        requestPermissionActivityContract
-                ) { granted -> onHealthConnectPermissionCallback(granted) }
+        try {
+            val requestPermissionActivityContract =
+                    PermissionController.createRequestPermissionResultContract()
+            healthConnectRequestPermissionsLauncher =
+                    componentActivity.registerForActivityResult(requestPermissionActivityContract) {
+                            granted ->
+                        onHealthConnectPermissionCallback(granted)
+                    }
+        } catch (exception: Exception) {
+            healthConnectRequestPermissionsLauncher = null
+            Log.e("FLUTTER_HEALTH", "Unable to register permission launcher", exception)
+        }
     }
 
     override fun onDetachedFromActivityForConfigChanges() {
@@ -222,8 +295,12 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
         if (channel == null) {
             return
         }
-        activity = null
+        failPendingAuthorization(
+                "health_connect_activity_detached",
+                "Activity detached during Health Connect authorization",
+        )
         healthConnectRequestPermissionsLauncher = null
+        activity = null
     }
 
     /**
@@ -231,8 +308,31 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
      * Connect is installed and accessible.
      */
     private fun checkAvailability() {
-        healthConnectStatus = HealthConnectClient.getSdkStatus(context!!)
+        val appContext = context ?: throw IllegalStateException("Plugin is detached from context")
+        healthConnectStatus = HealthConnectClient.getSdkStatus(appContext)
         healthConnectAvailable = healthConnectStatus == HealthConnectClient.SDK_AVAILABLE
+    }
+
+    private fun initializeClientIfAvailable() {
+        checkAvailability()
+        if (healthConnectAvailable && !this::dataOperations.isInitialized) {
+            val appContext = context ?: throw IllegalStateException("Plugin is detached from context")
+            healthConnectClient = HealthConnectClient.getOrCreate(appContext)
+            initializeHelpers()
+        }
+    }
+
+    private fun ensureHealthConnectReady(result: Result): Boolean {
+        initializeClientIfAvailable()
+        if (healthConnectAvailable && this::dataOperations.isInitialized) {
+            return true
+        }
+        result.error(
+                "health_connect_unavailable",
+                "Health Connect is not available",
+                mapOf("sdkStatus" to healthConnectStatus),
+        )
+        return false
     }
 
     /**
@@ -261,15 +361,16 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
      * @param result Flutter result callback
      */
     private fun installHealthConnect(call: MethodCall, result: Result) {
+        val appContext = context ?: throw IllegalStateException("Plugin is detached from context")
         val uriString =
                 "market://details?id=com.google.android.apps.healthdata&url=healthconnect%3A%2F%2Fonboarding"
-        context!!.startActivity(
+        appContext.startActivity(
                 Intent(Intent.ACTION_VIEW).apply {
                     setPackage("com.android.vending")
                     data = android.net.Uri.parse(uriString)
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     putExtra("overlay", true)
-                    putExtra("callerId", context!!.packageName)
+                    putExtra("callerId", appContext.packageName)
                 }
         )
         result.success(null)
@@ -282,22 +383,24 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
      * @param permissionGranted Set of permission strings that were granted
      */
     private fun onHealthConnectPermissionCallback(permissionGranted: Set<String>) {
-        if (!isReplySubmitted) {
+        val pendingResult = mResult
+        if (!isReplySubmitted && pendingResult != null) {
+            isReplySubmitted = true
+            mResult = null
             if (permissionGranted.isEmpty()) {
-                mResult?.success(false)
+                pendingResult.success(false)
                 Log.i(
                         "FLUTTER_HEALTH",
                         "Health Connect permissions were not granted! Make sure to declare the required permissions in the AndroidManifest.xml file."
                 )
             } else {
-                mResult?.success(true)
+                pendingResult.success(true)
                 Log.i(
                         "FLUTTER_HEALTH",
                         "${permissionGranted.size} Health Connect permissions were granted!"
                 )
                 Log.i("FLUTTER_HEALTH", "Permissions granted: $permissionGranted")
             }
-            isReplySubmitted = true
         }
     }
 
@@ -309,28 +412,12 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
      * @param result Flutter result callback for permission request outcome
      */
     private fun requestAuthorization(call: MethodCall, result: Result) {
-        if (context == null) {
-            result.success(false)
-            return
-        }
-
-        if (healthConnectRequestPermissionsLauncher == null) {
-            result.success(false)
-            Log.i("FLUTTER_HEALTH", "Permission launcher not found")
-            return
-        }
-
-        // Store the result to be called in onHealthConnectPermissionCallback
-        mResult = result
-        isReplySubmitted = false
-
         val permList = dataOperations.preparePermissionsList(call)
         if (permList == null) {
             result.success(false)
             return
         }
-
-        healthConnectRequestPermissionsLauncher!!.launch(permList.toSet())
+        launchPermissionRequest(permList.toSet(), result)
     }
 
     /**
@@ -341,16 +428,9 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
      * @param result Flutter result callback for permission request outcome
      */
     private fun requestHealthDataHistoryAuthorization(call: MethodCall, result: Result) {
-        if (context == null || healthConnectRequestPermissionsLauncher == null) {
-            result.success(false)
-            Log.i("FLUTTER_HEALTH", "Permission launcher not found")
-            return
-        }
-
-        mResult = result
-        isReplySubmitted = false
-        healthConnectRequestPermissionsLauncher!!.launch(
-                setOf(HealthPermission.PERMISSION_READ_HEALTH_DATA_HISTORY)
+        launchPermissionRequest(
+                setOf(HealthPermission.PERMISSION_READ_HEALTH_DATA_HISTORY),
+                result,
         )
     }
 
@@ -362,16 +442,46 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
      * @param result Flutter result callback for permission request outcome
      */
     private fun requestHealthDataInBackgroundAuthorization(call: MethodCall, result: Result) {
-        if (context == null || healthConnectRequestPermissionsLauncher == null) {
-            result.success(false)
-            Log.i("FLUTTER_HEALTH", "Permission launcher not found")
+        launchPermissionRequest(
+                setOf(HealthPermission.PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND),
+                result,
+        )
+    }
+
+    private fun launchPermissionRequest(permissions: Set<String>, result: Result) {
+        val launcher = healthConnectRequestPermissionsLauncher
+        if (context == null || launcher == null) {
+            result.error(
+                    "health_connect_activity_unavailable",
+                    "Health Connect permission launcher is unavailable",
+                    null,
+            )
+            return
+        }
+        if (mResult != null && !isReplySubmitted) {
+            result.error(
+                    "health_connect_authorization_in_progress",
+                    "Another Health Connect authorization request is in progress",
+                    null,
+            )
             return
         }
 
         mResult = result
         isReplySubmitted = false
-        healthConnectRequestPermissionsLauncher!!.launch(
-                setOf(HealthPermission.PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND)
-        )
+        try {
+            launcher.launch(permissions)
+        } catch (exception: Exception) {
+            mResult = null
+            isReplySubmitted = true
+            result.failHealthConnect("requestAuthorization", exception)
+        }
+    }
+
+    private fun failPendingAuthorization(errorCode: String, message: String) {
+        val pendingResult = mResult ?: return
+        mResult = null
+        isReplySubmitted = true
+        pendingResult.error(errorCode, message, null)
     }
 }

--- a/android/src/test/kotlin/cachet/plugins/health/HealthConnectOperationTest.kt
+++ b/android/src/test/kotlin/cachet/plugins/health/HealthConnectOperationTest.kt
@@ -1,0 +1,112 @@
+package cachet.plugins.health
+
+import io.flutter.plugin.common.MethodChannel.Result
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HealthConnectOperationTest {
+    @Test
+    fun mapsKnownServiceConnectionFailures() {
+        assertEquals(
+                "health_connect_bind_failed",
+                healthConnectErrorCode(RuntimeException("Binding to service failed")),
+        )
+        assertEquals(
+                "health_connect_binder_died",
+                healthConnectErrorCode(RuntimeException("Binder died")),
+        )
+        assertEquals(
+                "health_connect_binding_died",
+                healthConnectErrorCode(RuntimeException("Binding died")),
+        )
+        assertEquals(
+                "health_connect_null_binding",
+                healthConnectErrorCode(RuntimeException("Null binding")),
+        )
+        assertEquals(
+                "health_connect_binder_died",
+                healthConnectErrorCode(RuntimeException("wrapper", IOException("Binder died"))),
+        )
+    }
+
+    @Test
+    fun mapsExpectedHealthConnectFailures() {
+        assertEquals("health_connect_security_error", healthConnectErrorCode(SecurityException()))
+        assertEquals("health_connect_io_error", healthConnectErrorCode(IOException()))
+        assertEquals(
+                "health_connect_cancelled",
+                healthConnectErrorCode(CancellationException()),
+        )
+        assertEquals(
+                "health_connect_invalid_argument",
+                healthConnectErrorCode(IllegalArgumentException()),
+        )
+        assertEquals(
+                "health_connect_invalid_state",
+                healthConnectErrorCode(IllegalStateException()),
+        )
+        assertEquals(
+                "health_connect_unsupported",
+                healthConnectErrorCode(UnsupportedOperationException()),
+        )
+        assertEquals(
+                "health_connect_unknown_error",
+                healthConnectErrorCode(RuntimeException()),
+        )
+    }
+
+    @Test
+    fun guardedResultCompletesOnlyOnce() {
+        val delegate = RecordingResult()
+        val result = GuardedResult(delegate, "hasPermissions")
+
+        result.success(true)
+        result.error("late_error", "ignored", null)
+
+        assertEquals(true, delegate.successValue)
+        assertNull(delegate.errorCode)
+        assertEquals(1, delegate.completionCount)
+    }
+
+    @Test
+    fun coroutineFailureCompletesWithStableError() = runBlocking {
+        val result = RecordingResult()
+
+        val job =
+                CoroutineScope(coroutineContext).launchHealthConnectOperation(
+                        "hasPermissions",
+                        result,
+                ) {
+                    throw RuntimeException("Binder died")
+                }
+        job.join()
+
+        assertEquals("health_connect_binder_died", result.errorCode)
+        assertEquals(1, result.completionCount)
+    }
+
+    private class RecordingResult : Result {
+        var successValue: Any? = null
+        var errorCode: String? = null
+        var completionCount = 0
+
+        override fun success(result: Any?) {
+            successValue = result
+            completionCount++
+        }
+
+        override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+            this.errorCode = errorCode
+            completionCount++
+        }
+
+        override fun notImplemented() {
+            completionCount++
+        }
+    }
+}

--- a/lib/src/health_plugin.dart
+++ b/lib/src/health_plugin.dart
@@ -126,10 +126,15 @@ class Health {
       _handleWorkoutRoute(mTypes, mPermissions);
     }
 
-    return await _channel.invokeMethod('hasPermissions', {
-      "types": mTypes.map((type) => type.name).toList(),
-      "permissions": mPermissions,
-    });
+    try {
+      return await _channel.invokeMethod('hasPermissions', {
+        "types": mTypes.map((type) => type.name).toList(),
+        "permissions": mPermissions,
+      });
+    } on PlatformException catch (e) {
+      debugPrint('$runtimeType - Health Connect permission check failed: ${e.code}');
+      return false;
+    }
   }
 
   /// Revokes Google Health Connect permissions on Android of all types.
@@ -397,11 +402,16 @@ class Health {
     }
 
     List<String> keys = mTypes.map((e) => e.name).toList();
-    final bool? isAuthorized = await _channel.invokeMethod('requestAuthorization', {
-      'types': keys,
-      "permissions": mPermissions,
-    });
-    return isAuthorized ?? false;
+    try {
+      final bool? isAuthorized = await _channel.invokeMethod('requestAuthorization', {
+        'types': keys,
+        "permissions": mPermissions,
+      });
+      return isAuthorized ?? false;
+    } on PlatformException catch (e) {
+      debugPrint('$runtimeType - Health Connect authorization failed: ${e.code}');
+      return false;
+    }
   }
 
   /// Obtains health and weight if BMI is requested on Android.

--- a/test/support/fixtures.dart
+++ b/test/support/fixtures.dart
@@ -22,7 +22,7 @@ class HealthFixtures {
       'source_id': sourceId,
       'source_name': sourceName,
       'recording_method': recordingMethod,
-      if (metadata != null) 'metadata': metadata,
+      'metadata': ?metadata,
     };
   }
 
@@ -52,7 +52,7 @@ class HealthFixtures {
       'source_id': sourceId,
       'source_name': sourceName,
       'recording_method': recordingMethod,
-      if (metadata != null) 'metadata': metadata,
+      'metadata': ?metadata,
     };
   }
 

--- a/test/support/method_channel_harness.dart
+++ b/test/support/method_channel_harness.dart
@@ -10,6 +10,7 @@ class MethodChannelHarness {
   final MethodChannel channel;
   final List<MethodCall> calls = <MethodCall>[];
   final Map<String, Object?> cannedResponses = <String, Object?>{};
+  final Map<String, PlatformException> cannedErrors = <String, PlatformException>{};
   MethodCallResponder? _responder;
 
   Future<void> setUp({MethodCallResponder? responder}) async {
@@ -25,6 +26,9 @@ class MethodChannelHarness {
         if (cannedResponses.containsKey(call.method)) {
           return cannedResponses[call.method];
         }
+        if (cannedErrors.containsKey(call.method)) {
+          throw cannedErrors[call.method]!;
+        }
         return null;
       },
     );
@@ -34,11 +38,16 @@ class MethodChannelHarness {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
     calls.clear();
     cannedResponses.clear();
+    cannedErrors.clear();
     _responder = null;
   }
 
   void when(String method, Object? response) {
     cannedResponses[method] = response;
+  }
+
+  void failWith(String method, PlatformException exception) {
+    cannedErrors[method] = exception;
   }
 
   MethodCall? lastCallFor(String method) {

--- a/test/support/stub_device_info.dart
+++ b/test/support/stub_device_info.dart
@@ -64,6 +64,7 @@ class StubDeviceInfoPlugin implements DeviceInfoPlugin {
           'physicalRamSize': 8192,
           'availableRamSize': 4096,
           'isiOSAppOnMac': false,
+          'isiOSAppOnVision': false,
           'utsname': {
             'sysname': 'stub-ios-sysname',
             'nodename': 'stub-ios-nodename',

--- a/test/unit/health_plugin_permissions_test.dart
+++ b/test/unit/health_plugin_permissions_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:health/health.dart';
 
@@ -43,6 +44,17 @@ void main() {
       expect(args['permissions'], [HealthDataAccess.READ.index, HealthDataAccess.READ.index]);
     });
 
+    test('hasPermissions returns false when Health Connect Binder dies', () async {
+      ctx.channel.failWith(
+        'hasPermissions',
+        PlatformException(code: 'health_connect_binder_died', message: 'Binder died'),
+      );
+
+      final result = await ctx.health.hasPermissions([HealthDataType.WEIGHT]);
+
+      expect(result, isFalse);
+    });
+
     test('requestAuthorization throws when permissions length mismatches types', () {
       expect(
         () => ctx.health.requestAuthorization(
@@ -77,6 +89,20 @@ void main() {
       final args = Map<String, dynamic>.from(call!.arguments as Map);
       expect(args['types'], [HealthDataType.STEPS.name]);
       expect(args['permissions'], [HealthDataAccess.READ.index]);
+    });
+
+    test('requestAuthorization returns false when service binding fails', () async {
+      ctx.channel.failWith(
+        'requestAuthorization',
+        PlatformException(code: 'health_connect_bind_failed', message: 'Binding to service failed'),
+      );
+
+      final result = await ctx.health.requestAuthorization(
+        [HealthDataType.WEIGHT],
+        permissions: [HealthDataAccess.READ_WRITE],
+      );
+
+      expect(result, isFalse);
     });
 
     test('revokePermissions calls channel', () async {


### PR DESCRIPTION
## Summary

- contain Android Health Connect Binder and service-binding failures at the native method-channel boundary
- guard permission and capability coroutines, plugin initialization, synchronous dispatch, authorization launchers, and engine/activity detachment
- complete Flutter results at most once and map native failures to stable, non-sensitive error codes
- return `false` from Dart permission APIs when Health Connect IPC fails instead of surfacing an unhandled platform exception
- add native and Flutter regression coverage for `Binder died` and `Binding to service failed`

## Problem

AndroidX Health Connect communicates with its provider through Binder. If that provider process dies, cannot bind, returns a null binding, or disconnects during a permission call, calls such as `getGrantedPermissions()` may fail with a `RemoteException`. Several permission and feature coroutines previously had no exception boundary, so the failure escaped on `Dispatchers.Main` and could terminate the host app.

The shared dispatch and lifecycle guards also cover synchronous input/state failures, unavailable Health Connect, concurrent authorization requests, permission launcher failures, and late or duplicate callbacks.

## Validation

- `flutter test` — 54 tests passed
- `flutter analyze lib test` — no issues
- `:health:testDebugUnitTest` — Android compilation and native unit tests passed in a consuming Flutter app
- whole-repository analysis has only the existing 18 naming infos in `example/lib/main.dart`
