### PR TITLE
fix(android): guard workout enrichment sub-queries to support minimum-scope reads

### DIFF
--- a/KUBIKOS_PATCH.md
+++ b/KUBIKOS_PATCH.md
@@ -1,0 +1,28 @@
+# Kubikos fork of `health`
+
+Fork of [`carp-dk/carp-health-flutter`](https://github.com/carp-dk/carp-health-flutter)
+(the `health` package, v13.3.1) with **one** behavioural change on branch
+`kubikos/guard-workout-subqueries`. Used by kubikos-app via a `dependency_overrides`
+git ref. `main` tracks upstream unchanged.
+
+## The change
+
+`android/.../HealthDataReader.kt` → `handleWorkoutData` enriches every
+`ExerciseSessionRecord` by sub-querying `DistanceRecord`,
+`TotalCaloriesBurnedRecord` and `StepsRecord`. Upstream runs those three reads
+**unguarded**, and the whole workout read is wrapped in
+`try { … } catch { result.success(emptyList()) }`. So if the consuming app does
+not hold `READ_STEPS`/`READ_DISTANCE`, the sub-query throws `SecurityException`
+→ the catch swallows it → **every imported workout silently disappears**.
+
+This forces apps to request Health Connect permissions for data types they never
+use (e.g. Steps), which Google Play rejects under the **"Minimum Scope"** policy.
+
+The patch wraps each of the three sub-queries in its own `try/catch`, so a missing
+permission enriches that field with `null` instead of aborting the whole read.
+Grep for `PATCH` in `HealthDataReader.kt`.
+
+## Upstream
+
+Intended for an upstream PR to `carp-dk/carp-health-flutter`. Once merged and
+released, kubikos-app should drop this fork and return to the pub package.

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
@@ -596,48 +596,76 @@ class HealthDataReader(
             val record = rec as ExerciseSessionRecord
             
             // Get distance data
-            val distanceRequest = healthConnectClient.readRecords(
-                ReadRecordsRequest(
-                    recordType = DistanceRecord::class,
-                    timeRangeFilter = TimeRangeFilter.between(
-                        record.startTime,
-                        record.endTime,
-                    ),
-                ),
-            )
+            // PATCH (see KUBIKOS_PATCH.md): each workout sub-query is individually
+            // guarded. Upstream runs these three reads unguarded, so a single
+            // missing READ permission raises a SecurityException that getData()
+            // catches and turns into an EMPTY workout result — silently dropping
+            // every session. Guarding each read lets an app request the minimum
+            // Health Connect scope (Google Play "Minimum Scope" policy) and enrich
+            // with null for any sub-type it did not request permission for.
             var totalDistance = 0.0
-            for (distanceRec in distanceRequest.records) {
-                totalDistance += distanceRec.distance.inMeters
+            try {
+                val distanceRequest = healthConnectClient.readRecords(
+                    ReadRecordsRequest(
+                        recordType = DistanceRecord::class,
+                        timeRangeFilter = TimeRangeFilter.between(
+                            record.startTime,
+                            record.endTime,
+                        ),
+                    ),
+                )
+                for (distanceRec in distanceRequest.records) {
+                    totalDistance += distanceRec.distance.inMeters
+                }
+            } catch (e: Exception) {
+                Log.w(
+                    "FLUTTER_HEALTH",
+                    "Workout distance enrichment skipped (permission not granted?): ${e.message}"
+                )
             }
 
-            // Get energy burned data
-            val energyBurnedRequest = healthConnectClient.readRecords(
-                ReadRecordsRequest(
-                    recordType = TotalCaloriesBurnedRecord::class,
-                    timeRangeFilter = TimeRangeFilter.between(
-                        record.startTime,
-                        record.endTime,
-                    ),
-                ),
-            )
+            // Get energy burned data (PATCH: guarded, see above)
             var totalEnergyBurned = 0.0
-            for (energyBurnedRec in energyBurnedRequest.records) {
-                totalEnergyBurned += energyBurnedRec.energy.inKilocalories
+            try {
+                val energyBurnedRequest = healthConnectClient.readRecords(
+                    ReadRecordsRequest(
+                        recordType = TotalCaloriesBurnedRecord::class,
+                        timeRangeFilter = TimeRangeFilter.between(
+                            record.startTime,
+                            record.endTime,
+                        ),
+                    ),
+                )
+                for (energyBurnedRec in energyBurnedRequest.records) {
+                    totalEnergyBurned += energyBurnedRec.energy.inKilocalories
+                }
+            } catch (e: Exception) {
+                Log.w(
+                    "FLUTTER_HEALTH",
+                    "Workout energy enrichment skipped (permission not granted?): ${e.message}"
+                )
             }
 
-            // Get steps data
-            val stepRequest = healthConnectClient.readRecords(
-                ReadRecordsRequest(
-                    recordType = StepsRecord::class,
-                    timeRangeFilter = TimeRangeFilter.between(
-                        record.startTime,
-                        record.endTime
-                    ),
-                ),
-            )
+            // Get steps data (PATCH: guarded, see above)
             var totalSteps = 0.0
-            for (stepRec in stepRequest.records) {
-                totalSteps += stepRec.count
+            try {
+                val stepRequest = healthConnectClient.readRecords(
+                    ReadRecordsRequest(
+                        recordType = StepsRecord::class,
+                        timeRangeFilter = TimeRangeFilter.between(
+                            record.startTime,
+                            record.endTime
+                        ),
+                    ),
+                )
+                for (stepRec in stepRequest.records) {
+                    totalSteps += stepRec.count
+                }
+            } catch (e: Exception) {
+                Log.w(
+                    "FLUTTER_HEALTH",
+                    "Workout steps enrichment skipped (permission not granted?): ${e.message}"
+                )
             }
 
             // Add final datapoint


### PR DESCRIPTION
## Problem

`HealthDataReader.handleWorkoutData` enriches every `ExerciseSessionRecord` by sub-querying `DistanceRecord`, `TotalCaloriesBurnedRecord` and `StepsRecord`. These three reads are unguarded, and the whole workout read in `getData` is wrapped in `try { … } catch { result.success(emptyList()) }`.

So if the consuming app does **not** hold `READ_STEPS`/`READ_DISTANCE`, the sub-query throws a `SecurityException`, the outer catch swallows it, and the read returns an **empty** list — silently dropping *every* workout, not just the missing enrichment field.

This forces apps that only need exercise/workout data to also request `READ_STEPS`/`READ_DISTANCE` even when they never use step/distance data. Google Play rejects that under the Health Connect **"Minimum Scope"** policy.

## Fix

Wrap each of the three enrichment sub-queries in its own `try/catch`. A missing permission now enriches that single field with `null` (via the existing `if (x == 0.0) null` mapping) instead of aborting the whole read. Behaviour is unchanged when all permissions are granted, and there is no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)