### PR TITLE
Android: complete Health Connect support for MINDFULNESS (write, read, aggregates, gating, typed API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 13.4.0
+
+* Android: Add support for `MindfulnessSessionRecord` (READ/WRITE/Aggregate) via the existing `MINDFULNESS` data type
+* Android: `writeHealthData` accepts optional `mindfulnessSessionType` (new `MindfulnessSessionType` enum) and `title` for `MINDFULNESS`; both are Android-only and ignored on iOS
+* Android: New `isMindfulnessSessionAvailable()` — the record is gated by the Health Connect version installed on the device
+* Android: Fix `Duration` aggregates returning nothing — `getHealthAggregateDataFromTypes` now reports them in minutes, which also repairs the `SLEEP_*` and `ACTIVITY_INTENSITY` aggregates
+
 ## 13.3.1
 
 * iOS: Fix issues with app crashing on iOS 15

--- a/README.md
+++ b/README.md
@@ -364,6 +364,38 @@ Furthermore, the plugin now exposes three new functions to help you check and re
 2. `isHealthDataInBackgroundAuthorized()`: Checks the current status of the Health Data in Background permission
 3. `requestHealthDataInBackgroundAuthorization()`: Requests the Health Data in Background permission.
 
+### Android: Mindfulness Sessions
+
+`HealthDataType.MINDFULNESS` maps to Health Connect's `MindfulnessSessionRecord`. Add the matching permissions to your `AndroidManifest.XML`:
+
+```XML
+<uses-permission android:name="android.permission.health.READ_MINDFULNESS"/>
+<uses-permission android:name="android.permission.health.WRITE_MINDFULNESS"/>
+```
+
+The record was added to Health Connect after its initial release, so it is only usable when the Health Connect version installed on the device supports it — which is independent of the plugin version. Check before use:
+
+```dart
+if (await health.isMindfulnessSessionAvailable()) { ... }
+```
+
+On a device without that support, requesting permissions returns false and reads return no data, rather than throwing. On iOS `isMindfulnessSessionAvailable()` always returns true.
+
+`writeHealthData` takes two optional extras for this type, both of which Health Connect stores and iOS ignores (HealthKit's `mindfulSession` sample has neither a subtype nor a title):
+
+```dart
+await health.writeHealthData(
+  value: 0, // ignored — the span is the data
+  type: HealthDataType.MINDFULNESS,
+  startTime: start,
+  endTime: end,
+  mindfulnessSessionType: MindfulnessSessionType.BREATHING,
+  title: 'Morning practice', // user-visible in Health Connect
+);
+```
+
+`MindfulnessSessionType` mirrors Health Connect's `MINDFULNESS_SESSION_TYPE_*` constants. Both arguments are optional and are only sent to the platform when supplied; an omitted session type is recorded as `UNKNOWN`, which is Health Connect's own catch-all for a session that fits none of the named categories. Passing either extra with any other data type throws an `ArgumentError`.
+
 ### Fetch single health data by UUID
 
 In order to retrieve a single record, it is required to provide `String uuid` and `HealthDataType type`.
@@ -431,7 +463,7 @@ The plugin supports the following [`HealthDataType`](https://pub.dev/documentati
 | DISTANCE_WALKING_RUNNING     | METERS                  | yes              |                           |                                                                                                                                    |
 | FLIGHTS_CLIMBED              | COUNT                   | yes              | yes                       |                                                                                                                                    |
 | DISTANCE_DELTA               | METERS                  |                  | yes                       |                                                                                                                                    |
-| MINDFULNESS                  | MINUTES                 | yes              |                           |                                                                                                                                    |
+| MINDFULNESS                  | MINUTES                 | yes              | yes                       | on Android this is a MindfulnessSessionRecord; the span is the value, as with the iOS mindfulSession sample. Optional `mindfulnessSessionType` + `title` on write (Android only). Gated by the installed Health Connect version — see `isMindfulnessSessionAvailable()` |
 | SLEEP_ASLEEP                 | MINUTES                 | yes              | yes                       | on iOS, this refers to asleepUnspecified, and on Android this refers to STAGE_TYPE_SLEEPING (asleep but specific stage is unknown) |
 | SLEEP_AWAKE                  | MINUTES                 | yes              | yes                       |                                                                                                                                    |
 | SLEEP_AWAKE_IN_BED           | MINUTES                 |                  | yes                       |                                                                                                                                    |

--- a/android/src/main/kotlin/cachet/plugins/health/HealthConstants.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthConstants.kt
@@ -30,6 +30,7 @@ object HealthConstants {
     const val HEART_RATE_VARIABILITY_RMSSD = "HEART_RATE_VARIABILITY_RMSSD"
     const val HEIGHT = "HEIGHT"
     const val MENSTRUATION_FLOW = "MENSTRUATION_FLOW"
+    const val MINDFULNESS = "MINDFULNESS"
     const val RESPIRATORY_RATE = "RESPIRATORY_RATE"
     const val RESTING_HEART_RATE = "RESTING_HEART_RATE"
     const val STEPS = "STEPS"
@@ -97,6 +98,7 @@ object HealthConstants {
         SLEEP_OUT_OF_BED to SleepSessionRecord::class,
         SLEEP_SESSION to SleepSessionRecord::class,
         SLEEP_UNKNOWN to SleepSessionRecord::class,
+        MINDFULNESS to MindfulnessSessionRecord::class,
         WORKOUT to ExerciseSessionRecord::class,
         NUTRITION to NutritionRecord::class,
         RESTING_HEART_RATE to RestingHeartRateRecord::class,
@@ -128,6 +130,7 @@ object HealthConstants {
         SLEEP_ASLEEP to SleepSessionRecord.SLEEP_DURATION_TOTAL,
         SLEEP_AWAKE to SleepSessionRecord.SLEEP_DURATION_TOTAL,
         SLEEP_IN_BED to SleepSessionRecord.SLEEP_DURATION_TOTAL,
+        MINDFULNESS to MindfulnessSessionRecord.MINDFULNESS_DURATION_TOTAL,
         TOTAL_CALORIES_BURNED to TotalCaloriesBurnedRecord.ENERGY_TOTAL,
         ACTIVITY_INTENSITY to ActivityIntensityRecord.INTENSITY_MINUTES_TOTAL,
         SKIN_TEMPERATURE to SkinTemperatureRecord.TEMPERATURE_DELTA_AVG,

--- a/android/src/main/kotlin/cachet/plugins/health/HealthConstants.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthConstants.kt
@@ -182,6 +182,22 @@ object HealthConstants {
     )
 
     /**
+     * Maps mindfulness session type strings to Health Connect MindfulnessSessionRecord types.
+     * Health Connect has no separate "other" type — MINDFULNESS_SESSION_TYPE_UNKNOWN is its
+     * documented catch-all for a session that fits none of the named categories.
+     *
+     * @return Map<String, Int> Session type strings to Health Connect mindfulness type constants
+     */
+    val mindfulnessSessionTypeMap = mapOf(
+        "UNKNOWN" to MindfulnessSessionRecord.MINDFULNESS_SESSION_TYPE_UNKNOWN,
+        "MEDITATION" to MindfulnessSessionRecord.MINDFULNESS_SESSION_TYPE_MEDITATION,
+        "BREATHING" to MindfulnessSessionRecord.MINDFULNESS_SESSION_TYPE_BREATHING,
+        "MUSIC" to MindfulnessSessionRecord.MINDFULNESS_SESSION_TYPE_MUSIC,
+        "MOVEMENT" to MindfulnessSessionRecord.MINDFULNESS_SESSION_TYPE_MOVEMENT,
+        "UNGUIDED" to MindfulnessSessionRecord.MINDFULNESS_SESSION_TYPE_UNGUIDED,
+    )
+
+    /**
      * Maps workout/exercise type strings to Health Connect ExerciseSessionRecord types.
      * Comprehensive mapping of all supported exercise activities for workout tracking.
      * 

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataChanges.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataChanges.kt
@@ -170,6 +170,7 @@ class HealthDataChanges(
         is DistanceRecord -> listOf(HealthConstants.DISTANCE_DELTA)
         is HydrationRecord -> listOf(HealthConstants.WATER)
         is SleepSessionRecord -> listOf(HealthConstants.SLEEP_SESSION)
+        is MindfulnessSessionRecord -> listOf(HealthConstants.MINDFULNESS)
         is NutritionRecord -> listOf(HealthConstants.NUTRITION)
         is RestingHeartRateRecord -> listOf(HealthConstants.RESTING_HEART_RATE)
         is BasalMetabolicRateRecord -> listOf(HealthConstants.BASAL_ENERGY_BURNED)

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataConverter.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataConverter.kt
@@ -126,6 +126,17 @@ class HealthDataConverter {
                 )
             )
             
+            // Reported in minutes, like the sleep session above and like the iOS
+            // `.mindfulSession` sample — the span is the value.
+            is MindfulnessSessionRecord -> listOf(
+                createIntervalRecord(
+                    metadata,
+                    record.startTime,
+                    record.endTime,
+                    ChronoUnit.MINUTES.between(record.startTime, record.endTime)
+                )
+            )
+
             is MenstruationFlowRecord -> listOf(
                 createInstantRecord(metadata, record.time, record.flow)
             )

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataOperations.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataOperations.kt
@@ -184,6 +184,18 @@ class HealthDataOperations(
     }
 
     /**
+     * Checks if mindfulness sessions are supported by the Health Connect installed on this device.
+     * The record type was added to Health Connect after its initial release, so an up-to-date app
+     * can still meet a Health Connect that does not know it.
+     *
+     * @param call Method call from Flutter (unused)
+     * @param result Flutter result callback returning boolean availability status
+     */
+    fun isMindfulnessSessionAvailable(call: MethodCall, result: Result) {
+        result.success(HealthFeatures.isMindfulnessSessionAvailable(healthConnectClient))
+    }
+
+    /**
      * Deletes all health records of a specified type within a given time range. Performs bulk
      * deletion based on data type and time window.
      *
@@ -338,6 +350,15 @@ class HealthDataOperations(
             }
             if (!HealthConstants.mapToType.containsKey(typeKey)) {
                 Log.w("FLUTTER_HEALTH::ERROR", "Datatype $typeKey not found in HC")
+                return null
+            }
+
+            // Asking for a permission this device's Health Connect does not define would fail
+            // inside the permission contract; refuse up front instead.
+            if (typeKey == HealthConstants.MINDFULNESS &&
+                            !HealthFeatures.isMindfulnessSessionAvailable(healthConnectClient)
+            ) {
+                Log.w("FLUTTER_HEALTH::ERROR", HealthFeatures.MINDFULNESS_UNSUPPORTED_MESSAGE)
                 return null
             }
 

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
@@ -426,6 +426,12 @@ class HealthDataReader(
                             totalValue = totalValue.inKilocalories
                         } else if (totalValue is TemperatureDelta) {
                             totalValue = totalValue.inCelsius
+                        } else if (totalValue is Duration) {
+                            // A Duration cannot cross the method channel — encoding one
+                            // throws and takes the whole query down. Report minutes, the
+                            // unit every duration-aggregated type already declares in
+                            // `dataTypeToUnit`.
+                            totalValue = totalValue.toMinutes()
                         }
 
                         val packageNames = durationResult.result.dataOrigins

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
@@ -55,6 +55,11 @@ class HealthDataReader(
             "Getting data for $dataType with unit $dataUnit between $startTime and $endTime, filtering by $recordingMethodsToFilter"
         )
 
+        if (isUnsupportedMindfulness(dataType)) {
+            result.success(healthConnectData)
+            return
+        }
+
         scope.launch {
             try {
                 val grantedPermissions =
@@ -407,7 +412,12 @@ class HealthDataReader(
         val startTime = Instant.ofEpochMilli(call.argument<Long>("startTime")!!)
         val endTime = Instant.ofEpochMilli(call.argument<Long>("endTime")!!)
         val healthConnectData = mutableListOf<Map<String, Any?>>()
-        
+
+        if (isUnsupportedMindfulness(dataType)) {
+            result.success(healthConnectData)
+            return
+        }
+
         scope.launch {
             try {
                 HealthConstants.mapToAggregateMetric[dataType]?.let { metricClassType ->
@@ -492,6 +502,21 @@ class HealthDataReader(
     }
 
     // --------- Private Methods ---------
+
+    /**
+     * Whether a query for [dataType] asks for mindfulness sessions on a device whose Health Connect
+     * does not know the record. Such a query would fail inside Health Connect, so callers answer
+     * with no data instead — the same shape as a query for a type that yielded no records.
+     *
+     * @param dataType Health data type string being requested
+     * @return Boolean True when the query must be skipped
+     */
+    private fun isUnsupportedMindfulness(dataType: String): Boolean {
+        if (dataType != HealthConstants.MINDFULNESS) return false
+        if (HealthFeatures.isMindfulnessSessionAvailable(healthConnectClient)) return false
+        Log.w("FLUTTER_HEALTH::ERROR", HealthFeatures.MINDFULNESS_UNSUPPORTED_MESSAGE)
+        return true
+    }
 
     /**
      * Retrieves aggregated step count using Health Connect's built-in aggregation.

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataWriter.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataWriter.kt
@@ -789,6 +789,19 @@ class HealthDataWriter(
                             endZoneOffset = null,
                             metadata = metadata,
                     )
+            // The span IS the data, exactly like the iOS `.mindfulSession` category
+            // sample, so `value` is unused. The generic write API carries no session
+            // subtype, hence the neutral UNKNOWN.
+            MINDFULNESS ->
+                    MindfulnessSessionRecord(
+                            startTime = Instant.ofEpochMilli(startTime),
+                            endTime = Instant.ofEpochMilli(endTime),
+                            startZoneOffset = null,
+                            endZoneOffset = null,
+                            mindfulnessSessionType =
+                                    MindfulnessSessionRecord.MINDFULNESS_SESSION_TYPE_UNKNOWN,
+                            metadata = metadata,
+                    )
             RESTING_HEART_RATE ->
                     RestingHeartRateRecord(
                             time = Instant.ofEpochMilli(startTime),
@@ -959,6 +972,9 @@ class HealthDataWriter(
         private const val SLEEP_AWAKE_IN_BED = "SLEEP_AWAKE_IN_BED"
         private const val SLEEP_UNKNOWN = "SLEEP_UNKNOWN"
         private const val SLEEP_SESSION = "SLEEP_SESSION"
+
+        // Mindfulness
+        private const val MINDFULNESS = "MINDFULNESS"
     }
 
     fun finishWorkoutRoute(call: MethodCall, result: Result) {

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataWriter.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataWriter.kt
@@ -128,7 +128,7 @@ class HealthDataWriter(
      * automatic type conversion and validation.
      *
      * @param call Method call containing 'dataTypeKey', 'startTime', 'endTime', 'value',
-     * 'recordingMethod'
+     * 'recordingMethod', and for MINDFULNESS the optional 'mindfulnessSessionType' and 'title'
      * @param result Flutter result callback returning boolean success status
      */
     fun writeData(call: MethodCall, result: Result) {
@@ -140,6 +140,9 @@ class HealthDataWriter(
         val clientRecordVersion: Double? = call.argument<Double>("clientRecordVersion")
         val recordingMethod = call.argument<Int>("recordingMethod")!!
         val deviceType: Int? = call.argument<Int>("deviceType")
+        // Absent for every type but MINDFULNESS, and optional even there.
+        val mindfulnessSessionType = call.argument<String>("mindfulnessSessionType")
+        val title = call.argument<String>("title")
 
         Log.i(
                 "FLUTTER_HEALTH",
@@ -161,7 +164,16 @@ class HealthDataWriter(
             deviceType = deviceType,
         )
 
-        val record = createRecord(type, startTime, endTime, value, metadata)
+        val record =
+                createRecord(
+                        type,
+                        startTime,
+                        endTime,
+                        value,
+                        metadata,
+                        mindfulnessSessionType,
+                        title,
+                )
 
         if (record == null) {
             result.success(false)
@@ -592,7 +604,9 @@ class HealthDataWriter(
      * @param startTime Record start time in milliseconds
      * @param endTime Record end time in milliseconds
      * @param value Measured value to record
-     * @param recordingMethod How the data was recorded (manual, automatic, etc.)
+     * @param metadata Record metadata carrying the recording method and device attribution
+     * @param mindfulnessSessionType MINDFULNESS only — session type name, or null for unknown
+     * @param title MINDFULNESS only — user-visible session name, or null for none
      * @return Record? Properly configured Health Connect record, or null if type unsupported
      */
     private fun createRecord(
@@ -600,7 +614,9 @@ class HealthDataWriter(
             startTime: Long,
             endTime: Long,
             value: Double,
-            metadata: Metadata
+            metadata: Metadata,
+            mindfulnessSessionType: String? = null,
+            title: String? = null,
     ): Record? {
         return when (type) {
             BODY_FAT_PERCENTAGE ->
@@ -798,8 +814,9 @@ class HealthDataWriter(
                             metadata = metadata,
                     )
             // The span IS the data, exactly like the iOS `.mindfulSession` category
-            // sample, so `value` is unused. The generic write API carries no session
-            // subtype, hence the neutral UNKNOWN.
+            // sample, so `value` is unused. The session type and title are the two
+            // things Health Connect can say that HealthKit cannot; both are optional
+            // and default to an untyped, untitled session.
             MINDFULNESS ->
                     MindfulnessSessionRecord(
                             startTime = Instant.ofEpochMilli(startTime),
@@ -807,7 +824,11 @@ class HealthDataWriter(
                             startZoneOffset = null,
                             endZoneOffset = null,
                             mindfulnessSessionType =
-                                    MindfulnessSessionRecord.MINDFULNESS_SESSION_TYPE_UNKNOWN,
+                                    HealthConstants.mindfulnessSessionTypeMap[
+                                            mindfulnessSessionType]
+                                            ?: MindfulnessSessionRecord
+                                                    .MINDFULNESS_SESSION_TYPE_UNKNOWN,
+                            title = title,
                             metadata = metadata,
                     )
             RESTING_HEART_RATE ->

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataWriter.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataWriter.kt
@@ -146,6 +146,14 @@ class HealthDataWriter(
                 "Writing data for $type between $startTime and $endTime, value: $value, recording method: $recordingMethod"
         )
 
+        if (type == MINDFULNESS &&
+                        !HealthFeatures.isMindfulnessSessionAvailable(healthConnectClient)
+        ) {
+            Log.w("FLUTTER_HEALTH::ERROR", HealthFeatures.MINDFULNESS_UNSUPPORTED_MESSAGE)
+            result.success(false)
+            return
+        }
+
         val metadata: Metadata = buildMetadata(
             recordingMethod = recordingMethod,
             clientRecordId = clientRecordId,

--- a/android/src/main/kotlin/cachet/plugins/health/HealthFeatures.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthFeatures.kt
@@ -1,0 +1,36 @@
+package cachet.plugins.health
+
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.HealthConnectFeatures
+
+/**
+ * Availability of Health Connect record types that are gated by the version of the Health Connect
+ * implementation *installed on the device*, rather than by the version of `connect-client` this
+ * plugin is compiled against.
+ *
+ * A record can therefore be perfectly resolvable at compile time and still be rejected at runtime.
+ * The helpers here let the plugin answer "not supported here" instead of surfacing the platform
+ * exception that such a call would otherwise raise.
+ */
+object HealthFeatures {
+
+    /**
+     * Whether this device's Health Connect knows the mindfulness session record.
+     *
+     * `MindfulnessSessionRecord` was added to Health Connect after the initial release, so on an
+     * older Health Connect the record type is unknown and reading, writing, or even requesting its
+     * permissions fails. Guarding on this keeps those paths to a clean negative result.
+     *
+     * @param client The Health Connect client to interrogate
+     * @return Boolean True when mindfulness sessions can be used on this device
+     */
+    fun isMindfulnessSessionAvailable(client: HealthConnectClient): Boolean =
+            client.features.getFeatureStatus(
+                    HealthConnectFeatures.FEATURE_MINDFULNESS_SESSION
+            ) == HealthConnectFeatures.FEATURE_STATUS_AVAILABLE
+
+    /** Log message shared by every call that had to bail out on an unsupported device. */
+    internal const val MINDFULNESS_UNSUPPORTED_MESSAGE =
+            "[Health Connect] Mindfulness sessions are not supported by the version of " +
+                    "Health Connect installed on this device"
+}

--- a/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -152,6 +152,10 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
             "isSkinTemperatureAvailable" ->
                     dataOperations.isSkinTemperatureAvailable(call, result)
 
+            // Record types gated by the installed Health Connect version
+            "isMindfulnessSessionAvailable" ->
+                    dataOperations.isMindfulnessSessionAvailable(call, result)
+
             // Reading data
             "getData" -> dataReader.getData(call, result)
             "getDataByUUID" -> dataReader.getDataByUUID(call, result)
@@ -330,7 +334,18 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
             return
         }
 
-        healthConnectRequestPermissionsLauncher!!.launch(permList.toSet())
+        try {
+            healthConnectRequestPermissionsLauncher!!.launch(permList.toSet())
+        } catch (e: Exception) {
+            // Health Connect can be updated, downgraded, or disabled between the
+            // availability checks that built this list and the launch itself, at which
+            // point the contract rejects a permission string it no longer resolves.
+            // Answer "not granted" instead of throwing out of the plugin.
+            Log.e("FLUTTER_HEALTH::ERROR", "Unable to launch the permission request")
+            Log.e("FLUTTER_HEALTH::ERROR", Log.getStackTraceString(e))
+            isReplySubmitted = true
+            result.success(false)
+        }
     }
 
     /**

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -59,6 +59,8 @@
     <uses-permission android:name="android.permission.health.WRITE_LEAN_BODY_MASS"/>
     <uses-permission android:name="android.permission.health.READ_SKIN_TEMPERATURE"/>
     <uses-permission android:name="android.permission.health.WRITE_SKIN_TEMPERATURE"/>
+    <uses-permission android:name="android.permission.health.READ_MINDFULNESS"/>
+    <uses-permission android:name="android.permission.health.WRITE_MINDFULNESS"/>
 
     <!-- For reading historical data - more than 30 days ago since permission given -->
     <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_HISTORY"/>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -712,14 +712,19 @@ class HealthAppState extends State<HealthApp> {
       );
     }
 
-    if (Platform.isIOS) {
-      // Mindfulness value should be counted based on start and end time
+    // Mindfulness value should be counted based on start and end time.
+    // On Android the record only exists if the installed Health Connect
+    // supports it, and it can additionally carry a session type and a title -
+    // both of which iOS ignores.
+    if (await health.isMindfulnessSessionAvailable()) {
       success &= await health.writeHealthData(
         value: 10,
         type: HealthDataType.MINDFULNESS,
         startTime: earlier,
         endTime: now,
         recordingMethod: RecordingMethod.automatic,
+        mindfulnessSessionType: MindfulnessSessionType.BREATHING,
+        title: 'Morning practice',
       );
     }
 

--- a/example/lib/util.dart
+++ b/example/lib/util.dart
@@ -101,6 +101,7 @@ const List<HealthDataType> dataTypesAndroid = [
   HealthDataType.SLEEP_REM,
   HealthDataType.SLEEP_UNKNOWN,
   HealthDataType.SLEEP_SESSION,
+  HealthDataType.MINDFULNESS,
   HealthDataType.WATER,
   HealthDataType.WORKOUT,
   HealthDataType.WORKOUT_ROUTE,

--- a/lib/src/health_plugin.dart
+++ b/lib/src/health_plugin.dart
@@ -548,6 +548,17 @@ class Health {
   ///    only at a specific point in time (default).
   ///  * [recordingMethod] - the recording method of the data point, automatic by default.
   ///    (on iOS this must be manual or automatic)
+  ///  * [mindfulnessSessionType] - **[HealthDataType.MINDFULNESS] ONLY, Android
+  ///    only** the kind of mindfulness session this entry records. Omit it (or
+  ///    pass null) to leave the session untyped, which Health Connect records as
+  ///    [MindfulnessSessionType.UNKNOWN]. Ignored on iOS: HealthKit's
+  ///    `.mindfulSession` category has no subtype.
+  ///  * [title] - **[HealthDataType.MINDFULNESS] ONLY, Android only** a
+  ///    user-visible name for the session, shown in Health Connect. Ignored on
+  ///    iOS, where a mindfulness sample carries no title.
+  ///
+  /// Passing [mindfulnessSessionType] or [title] with any other [type] throws
+  /// an [ArgumentError] rather than dropping them silently.
   ///
   /// Values for Sleep and Headache are ignored and will be automatically assigned
   /// the default value.
@@ -560,6 +571,8 @@ class Health {
     double? clientRecordVersion,
     DateTime? endTime,
     RecordingMethod recordingMethod = RecordingMethod.automatic,
+    MindfulnessSessionType? mindfulnessSessionType,
+    String? title,
   }) async {
     await _checkIfHealthConnectAvailableOnAndroid();
     await _checkIfDataTypeAvailableOnDevice(type);
@@ -572,6 +585,9 @@ class Health {
     }
     if (type == HealthDataType.ACTIVITY_INTENSITY) {
       throw ArgumentError("Adding activity intensity data should be done using the writeActivityIntensity method.");
+    }
+    if (type != HealthDataType.MINDFULNESS && (mindfulnessSessionType != null || title != null)) {
+      throw ArgumentError("mindfulnessSessionType and title only apply to ${HealthDataType.MINDFULNESS}.");
     }
     // If not implemented on platform, throw an exception
     if (!isDataTypeAvailable(type)) {
@@ -619,6 +635,10 @@ class Health {
       'recordingMethod': recordingMethod.toInt(),
       'clientRecordId': clientRecordId,
       'clientRecordVersion': clientRecordVersion,
+      // Only sent when the caller actually supplied them, so a write that does
+      // not use them puts the same payload on the wire it always did.
+      'mindfulnessSessionType': ?mindfulnessSessionType?.name,
+      'title': ?title,
     };
     bool? success = await _channel.invokeMethod('writeData', args);
     return success ?? false;

--- a/lib/src/health_plugin.dart
+++ b/lib/src/health_plugin.dart
@@ -341,6 +341,31 @@ class Health {
     }
   }
 
+  /// Checks if [HealthDataType.MINDFULNESS] can be used on this device.
+  ///
+  /// On Android, mindfulness sessions were added to Health Connect after its
+  /// initial release, so the record type is only usable when the Health Connect
+  /// version installed on the device knows it. Reading, writing, or requesting
+  /// permissions for [HealthDataType.MINDFULNESS] without this check returns
+  /// false / no data on such a device.
+  ///
+  /// See this for more info: https://developer.android.com/reference/androidx/health/connect/client/HealthConnectFeatures#FEATURE_MINDFULNESS_SESSION()
+  ///
+  /// Returns true on iOS, where HealthKit always supports mindful sessions, and
+  /// false if Health Connect is unavailable or an error occurs.
+  Future<bool> isMindfulnessSessionAvailable() async {
+    if (Platform.isIOS) return true;
+    if (!(await isHealthConnectAvailable())) return false;
+
+    try {
+      final status = await _channel.invokeMethod<bool>('isMindfulnessSessionAvailable');
+      return status ?? false;
+    } catch (e) {
+      debugPrint('$runtimeType - Exception in isMindfulnessSessionAvailable(): $e');
+      return false;
+    }
+  }
+
   /// Requests permissions to access health data [types].
   ///
   /// Returns true if successful, false otherwise.

--- a/lib/src/heath_data_types.dart
+++ b/lib/src/heath_data_types.dart
@@ -256,6 +256,7 @@ const List<HealthDataType> dataTypeKeysAndroid = [
   HealthDataType.SLEEP_REM,
   HealthDataType.SLEEP_SESSION,
   HealthDataType.SLEEP_UNKNOWN,
+  HealthDataType.MINDFULNESS,
   HealthDataType.WATER,
   HealthDataType.WORKOUT,
   HealthDataType.WORKOUT_ROUTE,

--- a/lib/src/heath_data_types.dart
+++ b/lib/src/heath_data_types.dart
@@ -485,6 +485,35 @@ enum HealthDataUnit {
   NO_UNIT,
 }
 
+/// The kind of session a [HealthDataType.MINDFULNESS] entry records.
+///
+/// Mirrors Health Connect's `MindfulnessSessionRecord.MINDFULNESS_SESSION_TYPE_*`
+/// constants one-for-one.
+///
+/// **Android only.** HealthKit's `.mindfulSession` category has no subtype, so
+/// iOS ignores it and every mindfulness entry looks the same there.
+enum MindfulnessSessionType {
+  /// Any generic mindfulness session that does not fall into one of the
+  /// categories below. This is the default, and what Health Connect itself
+  /// documents as the catch-all — there is no separate "other" type.
+  UNKNOWN,
+
+  /// Meditation.
+  MEDITATION,
+
+  /// Guided breathing.
+  BREATHING,
+
+  /// Music / soundscapes.
+  MUSIC,
+
+  /// Stretches / movement.
+  MOVEMENT,
+
+  /// Unguided practice.
+  UNGUIDED,
+}
+
 /// List of [HealthWorkoutActivityType]s.
 enum HealthWorkoutActivityType {
   // Commented for which platform the type are supported

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: health
 description: Wrapper for Apple's HealthKit on iOS and Google's Health Connect on Android.
-version: 13.3.1
+version: 13.4.0
 homepage: https://github.com/carp-dk/carp-health-flutter
 
 environment:


### PR DESCRIPTION
This completes MINDFULNESS support on Android. The demand is visible in #460 by @lekanbar, which maps the write path; credit to him for the initial mapping and to everyone there confirming the need. This PR is a superset written independently, and I am happy to rebase it on top of #460 if you prefer to land that first.

**What it adds**

* Write, read, and aggregate support for `MindfulnessSessionRecord`. Reads convert to an interval record in minutes, matching `SLEEP_SESSION`. `MINDFULNESS_DURATION_TOTAL` is registered for aggregates.
* A `MindfulnessSessionType` enum mirroring the platform constants one to one, plus an optional `title`, both on `writeHealthData` and only valid for MINDFULNESS (`ArgumentError` otherwise, like the existing WORKOUT guard). The default is `UNKNOWN`, which Health Connect documents as the generic bucket. Without this every entry would be labeled as meditation even when it is a breathing exercise. iOS ignores both extras since HealthKit's `mindfulSession` has no subtype or title; the docs say so.
* Runtime availability gating. `MindfulnessSessionRecord` postdates Health Connect's initial release, so a current plugin can meet an installed Health Connect that does not know the type. `writeData`, `getData`, `getAggregateData`, and the permission list are gated on `HealthConnectFeatures.FEATURE_MINDFULNESS_SESSION`, each answering with a clean negative. `isMindfulnessSessionAvailable()` is exposed to Dart, following `isSkinTemperatureAvailable()`.
* A defensive permission launch: Health Connect can change between building the permission list and launching the contract, which currently throws out of the plugin into the host app. It now answers not granted.
* A fix with reach beyond mindfulness: aggregate results of type `java.time.Duration` could not cross the method channel, so `SLEEP_*` and `ACTIVITY_INTENSITY` duration aggregates silently returned nothing. They now return minutes.
* `getChanges` names the type (`dataTypesForRecord`), README section and data-type row, CHANGELOG under 13.4.0, and the example app exercises an availability-guarded write with session type and title.

**Notes for review**

* Wire compatibility is preserved: calls that do not pass the new arguments produce the exact payload they produced before, so existing method-channel mocks and custom native counterparts are unaffected.
* One deliberate divergence from the `SKIN_TEMPERATURE` convention: unsupported mindfulness answers false or empty instead of throwing `HealthException`. The permission path cannot surface a Dart exception usefully, and a capability an app can branch on seemed more ergonomic. Easy to flip if you prefer consistency.
* Verified against the `connect-client 1.2.0-alpha02` artifact: the mindfulness API is stable there (no opt-in), and the permission string values are `android.permission.health.READ_MINDFULNESS` and `WRITE_MINDFULNESS`.
* `flutter analyze` and `flutter test` results are identical to `main` before and after (the 49 failing tests on `main` come from a pre-existing `device_info_plus` fixture fault and are untouched). The plugin compiles against 1.2.0-alpha02 and the example app builds with compileSdk 36.

Written for a shipped app that records breathing sessions and cold exposure; both paths run on real devices against the Health Connect UI.
