### PR TITLE
Fail loudly when the host Activity is not a ComponentActivity

### DIFF
--- a/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -298,17 +298,17 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
         if (!isReplySubmitted) {
             if (permissionGranted.isEmpty()) {
                 mResult?.success(false)
-                Log.i(
+                Log.e(
                         "FLUTTER_HEALTH",
                         "Health Connect permissions were not granted! Make sure to declare the required permissions in the AndroidManifest.xml file."
                 )
             } else {
                 mResult?.success(true)
-                Log.i(
+                Log.e(
                         "FLUTTER_HEALTH",
                         "${permissionGranted.size} Health Connect permissions were granted!"
                 )
-                Log.i("FLUTTER_HEALTH", "Permissions granted: $permissionGranted")
+                Log.e("FLUTTER_HEALTH", "Permissions granted: $permissionGranted")
             }
             isReplySubmitted = true
         }
@@ -329,7 +329,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
 
         if (healthConnectRequestPermissionsLauncher == null) {
             result.success(false)
-            Log.("FLUTTER_HEALTH", "Permission launcher not found")
+            Log.e("FLUTTER_HEALTH", "Permission launcher not found")
             return
         }
 
@@ -356,7 +356,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
     private fun requestHealthDataHistoryAuthorization(call: MethodCall, result: Result) {
         if (context == null || healthConnectRequestPermissionsLauncher == null) {
             result.success(false)
-            Log.("FLUTTER_HEALTH", "Permission launcher not found")
+            Log.e("FLUTTER_HEALTH", "Permission launcher not found")
             return
         }
 
@@ -377,7 +377,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
     private fun requestHealthDataInBackgroundAuthorization(call: MethodCall, result: Result) {
         if (context == null || healthConnectRequestPermissionsLauncher == null) {
             result.success(false)
-            Log.("FLUTTER_HEALTH", "Permission launcher not found")
+            Log.e("FLUTTER_HEALTH", "Permission launcher not found")
             return
         }
 

--- a/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -190,18 +190,31 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
      *
      * @param binding Activity plugin binding providing activity context
      */
-    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+       override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         if (channel == null) {
             return
         }
         binding.addActivityResultListener(this)
         activity = binding.activity
 
+        val componentActivity = activity as? ComponentActivity
+        if (componentActivity == null) {
+            Log.e(
+                    "FLUTTER_HEALTH",
+                    "Host Activity is ${activity?.javaClass?.name}, which does not extend " +
+                            "androidx.activity.ComponentActivity, so Health Connect permissions " +
+                            "cannot be requested. Make MainActivity extend " +
+                            "io.flutter.embedding.android.FlutterFragmentActivity instead of " +
+                            "FlutterActivity — see 'Android setup' in the README."
+            )
+            return
+        }
+
         val requestPermissionActivityContract =
                 PermissionController.createRequestPermissionResultContract()
 
         healthConnectRequestPermissionsLauncher =
-                (activity as ComponentActivity).registerForActivityResult(
+                componentActivity.registerForActivityResult(
                         requestPermissionActivityContract
                 ) { granted -> onHealthConnectPermissionCallback(granted) }
     }
@@ -316,7 +329,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
 
         if (healthConnectRequestPermissionsLauncher == null) {
             result.success(false)
-            Log.i("FLUTTER_HEALTH", "Permission launcher not found")
+            Log.("FLUTTER_HEALTH", "Permission launcher not found")
             return
         }
 
@@ -343,7 +356,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
     private fun requestHealthDataHistoryAuthorization(call: MethodCall, result: Result) {
         if (context == null || healthConnectRequestPermissionsLauncher == null) {
             result.success(false)
-            Log.i("FLUTTER_HEALTH", "Permission launcher not found")
+            Log.("FLUTTER_HEALTH", "Permission launcher not found")
             return
         }
 
@@ -364,7 +377,7 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
     private fun requestHealthDataInBackgroundAuthorization(call: MethodCall, result: Result) {
         if (context == null || healthConnectRequestPermissionsLauncher == null) {
             result.success(false)
-            Log.i("FLUTTER_HEALTH", "Permission launcher not found")
+            Log.("FLUTTER_HEALTH", "Permission launcher not found")
             return
         }
 


### PR DESCRIPTION
Likely fixes #126 and #146, though I could not confirm the reporters' setups.

### The problem

`onAttachedToActivity` casts the host Activity with an unguarded `as`:

```kotlin
healthConnectRequestPermissionsLauncher =
        (activity as ComponentActivity).registerForActivityResult(...)
```

`io.flutter.embedding.android.FlutterActivity` — the default `MainActivity` base
class in a new Flutter app — extends `android.app.Activity`, not
`androidx.activity.ComponentActivity`. So the cast throws `ClassCastException`
during plugin attachment, and `healthConnectRequestPermissionsLauncher` is left
`null`.

From then on every permission entry point takes the null branch:

```kotlin
if (healthConnectRequestPermissionsLauncher == null) {
    result.success(false)
    Log.i("FLUTTER_HEALTH", "Permission launcher not found")
    return
}
```

The Dart side sees `requestAuthorization()` return `false`, with no exception
thrown. The only trace is an **info-level** log line that names a symptom
("Permission launcher not found") and not the cause. Nothing in that path points
at the host Activity's base class.

The README does document the `FlutterFragmentActivity` requirement under Android
setup. The gap is that when someone misses it, the runtime gives them no way back
to that instruction.

### The change

1. Replace the unguarded cast with `as?`. When it fails, log at **error** level
   with the actual Activity class name and the exact fix, then return instead of
   throwing.
2. Raise the "Permission launcher not found" logs from `Log.i` to `Log.e`, so the
   downstream symptom is visible at the same level as the cause.

No API or behavioural change for correctly configured apps.

### Alternative

I went with log-and-return rather than throwing an `IllegalStateException`, to
avoid turning a misconfiguration into a startup crash for apps that include the
plugin but never touch Health Connect on Android. Happy to switch it if you would
rather it fail fast.

### Testing

Verified on an Android emulator (`sdk_gphone64_x86_64`, API 34), building this
branch from source through a git dependency override in a real app.

With the host `MainActivity` extending `FlutterActivity`, the plugin now logs at
attach time:

```
E FLUTTER_HEALTH: Host Activity is br.com.lumia.MainActivity, which does not
extend androidx.activity.ComponentActivity, so Health Connect permissions cannot
be requested. Make MainActivity extend
io.flutter.embedding.android.FlutterFragmentActivity instead of FlutterActivity
— see 'Android setup' in the README.
```

The app then continues to start normally — the Dart side initialises and the UI
mounts — confirming the log-and-return path does not turn a misconfiguration into
a startup crash.

With `MainActivity` restored to `FlutterFragmentActivity`, the permission
launcher registers, no error is logged, and the app behaves as before.