### PR TITLE
chore: bump carp_serializable to ^3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 13.3.2
+
+* Bump `carp_serializable` constraint to `^3.0.0`
+
 ## 13.3.1
 
 * iOS: Fix issues with app crashing on iOS 15

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_example
 description: Demonstrates how to use the health plugin.
 publish_to: "none"
-version: 13.3.1
+version: 13.3.2
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.2
   permission_handler: ^11.3.1
-  carp_serializable: ^2.0.0 # polymorphic json serialization
+  carp_serializable: ^3.0.0 # polymorphic json serialization
   health:
     path: ../
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: health
 description: Wrapper for Apple's HealthKit on iOS and Google's Health Connect on Android.
-version: 13.3.1
+version: 13.3.2
 homepage: https://github.com/carp-dk/carp-health-flutter
 
 environment:
@@ -13,7 +13,7 @@ dependencies:
   intl: '>=0.18.0 <0.21.0'
   device_info_plus: '^12.1.0'
   json_annotation: ^4.9.0
-  carp_serializable: ^2.0.1 # polymorphic json serialization
+  carp_serializable: ^3.0.0 # polymorphic json serialization
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## What

Bumps the `carp_serializable` constraint to `^3.0.0` in the plugin and its example, and bumps the version to `13.3.2`.

## Why

Other carp packages have moved to `carp_serializable` 3.x. This plugin's `^2.x` pin blocks it from being used alongside them (e.g. via `carp_health_package` in apps on carp_serializable 3.x), causing version-solving failures.

## Safety

The only breaking change in serializable 3.0.0 is the `Uuid` API (`Uuid().v1` → `const Uuid().v4()`). This plugin does not use serializable's `Uuid`, only `Serializable`, `@JsonSerializable`, and `FromJsonFactory().fromJson<T>()`, all of which are unchanged in 3.0.0 — so **no code changes are required**.

## Verification

- `flutter analyze` on the example: **0 errors** (only pre-existing style lints).
- `flutter build apk --debug` on the example: **built successfully** (`✓ Built build/app/outputs/flutter-apk/app-debug.apk`).

The change is constraint-only and safe.