### PR TITLE
Add an optional limit to getHealthDataFromTypes (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Add an optional `limit` to `getHealthDataFromTypes()` - Fix [#279](https://github.com/carp-dk/carp-health-flutter/issues/279)
+* Fix the iOS device-info test stub so the unit suite runs on a fresh clone
+
 ## 13.3.2
 
 * Write data now returns UUID of records - PR [#448](https://github.com/carp-dk/carp-health-flutter/pull/448)

--- a/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
+++ b/android/src/main/kotlin/cachet/plugins/health/HealthDataReader.kt
@@ -49,6 +49,8 @@ class HealthDataReader(
         val endTime = Instant.ofEpochMilli(call.argument<Long>("endTime")!!)
         val healthConnectData = mutableListOf<Map<String, Any?>>()
         val recordingMethodsToFilter = call.argument<List<Int>>("recordingMethodsToFilter")!!
+        // Absent or 0 means no limit.
+        val limit = call.argument<Int>("limit")?.takeIf { it > 0 }
 
         Log.i(
             "FLUTTER_HEALTH",
@@ -81,11 +83,21 @@ class HealthDataReader(
                 authorizedTypeMap[dataType]?.let { classType ->
                     val records = mutableListOf<Record>()
 
-                    // Set up the initial request to read health records
-                    var request = ReadRecordsRequest(
-                        recordType = classType,
-                        timeRangeFilter = TimeRangeFilter.between(startTime, endTime),
-                    )
+                    // A limited read takes one page, newest first. Unlimited
+                    // reads pass neither argument and keep the SDK defaults.
+                    var request = if (limit == null) {
+                        ReadRecordsRequest(
+                            recordType = classType,
+                            timeRangeFilter = TimeRangeFilter.between(startTime, endTime),
+                        )
+                    } else {
+                        ReadRecordsRequest(
+                            recordType = classType,
+                            timeRangeFilter = TimeRangeFilter.between(startTime, endTime),
+                            ascendingOrder = false,
+                            pageSize = limit,
+                        )
+                    }
 
                     var response = healthConnectClient.readRecords(request)
                     var pageToken = response.pageToken
@@ -93,8 +105,8 @@ class HealthDataReader(
                     // Add the records from the initial response
                     records.addAll(response.records)
 
-                    // Continue making requests while there is a page token
-                    while (!pageToken.isNullOrEmpty()) {
+                    // A limited read is satisfied by the first page.
+                    while (limit == null && !pageToken.isNullOrEmpty()) {
                         request = ReadRecordsRequest(
                             recordType = classType,
                             timeRangeFilter = TimeRangeFilter.between(startTime, endTime),

--- a/lib/src/health_plugin.dart
+++ b/lib/src/health_plugin.dart
@@ -1240,13 +1240,37 @@ class Health {
   /// Fetch a list of health data points based on [types].
   /// You can also specify the [recordingMethodsToFilter] to filter the data points.
   /// If not specified, all data points will be included.
+  ///
+  /// [limit] caps how much is read per type, newest first. Null or 0 means no
+  /// limit; a negative [limit] throws [ArgumentError].
+  ///
+  /// What it bounds differs by platform. iOS limits SAMPLES, so [limit] is a
+  /// cap on returned points. Android limits Health Connect RECORDS, and some
+  /// record types expand to several points (a `HeartRateRecord` carries many
+  /// samples), so `limit: 1` on `HEART_RATE` can return more than one point.
+  /// For single-value types such as `WEIGHT` or `HEIGHT` the two coincide.
+  ///
+  /// Two further Android notes. `recordingMethodsToFilter` is applied AFTER
+  /// the limit, so a limited read can return fewer points than asked for when
+  /// the newest records are filtered out; iOS applies the filter in the query.
+  /// And a very large [limit] may exceed the platform's maximum page size and
+  /// be rejected, yielding an empty result - prefer a realistic value over a
+  /// large one used to mean "everything", and pass null for no limit.
+  ///
+  /// Unlimited reads are unaffected: no ordering or paging argument is sent,
+  /// so they keep the existing behaviour and ordering exactly.
   Future<List<HealthDataPoint>> getHealthDataFromTypes({
     required List<HealthDataType> types,
     Map<HealthDataType, HealthDataUnit>? preferredUnits,
     required DateTime startTime,
     required DateTime endTime,
     List<RecordingMethod> recordingMethodsToFilter = const [],
+    int? limit,
   }) async {
+    if (limit != null && limit < 0) {
+      throw ArgumentError.value(
+          limit, 'limit', 'must be null, 0 (no limit), or positive');
+    }
     await _checkIfHealthConnectAvailableOnAndroid();
     List<HealthDataPoint> dataPoints = [];
 
@@ -1257,6 +1281,7 @@ class Health {
         type,
         recordingMethodsToFilter,
         dataUnit: preferredUnits?[type],
+        limit: limit,
       );
       dataPoints.addAll(result);
     }
@@ -1377,6 +1402,7 @@ class Health {
     HealthDataType dataType,
     List<RecordingMethod> recordingMethodsToFilter, {
     HealthDataUnit? dataUnit,
+    int? limit,
   }) async {
     // Ask for device ID only once
     _deviceId ??= Platform.isAndroid
@@ -1393,7 +1419,7 @@ class Health {
     if (dataType == HealthDataType.BODY_MASS_INDEX && Platform.isAndroid) {
       return _computeAndroidBMI(startTime, endTime, recordingMethodsToFilter);
     }
-    return await _dataQuery(startTime, endTime, dataType, recordingMethodsToFilter, dataUnit: dataUnit);
+    return await _dataQuery(startTime, endTime, dataType, recordingMethodsToFilter, dataUnit: dataUnit, limit: limit);
   }
 
   /// Prepares an interval query, i.e. checks if the types are available, etc.
@@ -1449,6 +1475,7 @@ class Health {
     HealthDataType dataType,
     List<RecordingMethod> recordingMethodsToFilter, {
     HealthDataUnit? dataUnit,
+    int? limit,
   }) async {
     String? unit = dataUnit?.name ?? dataTypeToUnit[dataType]?.name;
     final args = <String, dynamic>{
@@ -1457,6 +1484,7 @@ class Health {
       'startTime': startTime.millisecondsSinceEpoch,
       'endTime': endTime.millisecondsSinceEpoch,
       'recordingMethodsToFilter': recordingMethodsToFilter.map((e) => e.toInt()).toList(),
+      if (limit != null && limit > 0) 'limit': limit,
     };
     final fetchedDataPoints = await _channel.invokeMethod('getData', args);
 

--- a/test/support/stub_device_info.dart
+++ b/test/support/stub_device_info.dart
@@ -58,6 +58,7 @@ class StubDeviceInfoPlugin implements DeviceInfoPlugin {
           'modelName': 'stub-ios-modelName',
           'localizedModel': 'stub-ios-localizedModel',
           'identifierForVendor': iosId,
+          'isiOSAppOnVision': false,
           'isPhysicalDevice': true,
           'freeDiskSize': 128000000000,
           'totalDiskSize': 256000000000,

--- a/test/unit/health_plugin_reads_test.dart
+++ b/test/unit/health_plugin_reads_test.dart
@@ -41,6 +41,62 @@ void main() {
       expect(args['recordingMethodsToFilter'], [RecordingMethod.manual.toInt()]);
     });
 
+    test('getHealthDataFromTypes forwards limit when set', () async {
+      ctx.channel.when('getData', [HealthFixtures.numericPoint()]);
+
+      await ctx.health.getHealthDataFromTypes(
+        types: [HealthDataType.WEIGHT],
+        startTime: HealthFixtures.start,
+        endTime: HealthFixtures.end,
+        limit: 1,
+      );
+
+      final args = Map<String, dynamic>.from(
+          ctx.channel.lastCallFor('getData')!.arguments as Map);
+      expect(args['limit'], 1);
+    });
+
+    test('getHealthDataFromTypes omits limit when unset', () async {
+      ctx.channel.when('getData', [HealthFixtures.numericPoint()]);
+
+      await ctx.health.getHealthDataFromTypes(
+        types: [HealthDataType.WEIGHT],
+        startTime: HealthFixtures.start,
+        endTime: HealthFixtures.end,
+      );
+
+      final args = Map<String, dynamic>.from(
+          ctx.channel.lastCallFor('getData')!.arguments as Map);
+      expect(args.containsKey('limit'), isFalse);
+    });
+
+    test('getHealthDataFromTypes treats limit 0 as no limit', () async {
+      ctx.channel.when('getData', [HealthFixtures.numericPoint()]);
+
+      await ctx.health.getHealthDataFromTypes(
+        types: [HealthDataType.WEIGHT],
+        startTime: HealthFixtures.start,
+        endTime: HealthFixtures.end,
+        limit: 0,
+      );
+
+      final args = Map<String, dynamic>.from(
+          ctx.channel.lastCallFor('getData')!.arguments as Map);
+      expect(args.containsKey('limit'), isFalse);
+    });
+
+    test('getHealthDataFromTypes rejects a negative limit', () {
+      expect(
+        () => ctx.health.getHealthDataFromTypes(
+          types: [HealthDataType.WEIGHT],
+          startTime: HealthFixtures.start,
+          endTime: HealthFixtures.end,
+          limit: -1,
+        ),
+        throwsArgumentError,
+      );
+    });
+
     test('getHealthDataByUUID throws when UUID is empty', () {
       expect(
         () => ctx.health.getHealthDataByUUID(uuid: '', type: HealthDataType.HEART_RATE),


### PR DESCRIPTION
Fixes #279.

Asking for the most recent sample of a type is expensive today. Height, or a starting weight, may have been recorded once and long ago, so a caller widens the window until it finds one, and on Android that read pages through every record in the range and materializes all of them before returning.

iOS already supported this: the native reader reads an optional `limit` and already sorts by end date descending. It was never sent from Dart. Android read no limit and looped over every page.

With a limit, Android now requests newest-first and stops at the first page. Without one it passes no ordering or paging argument at all, so unlimited reads keep the SDK defaults and behave as before. iOS needed no native change.

Null or `0` means no limit (`0` is the spelling proposed in the issue). A negative limit throws `ArgumentError`. Four tests cover set, unset, zero and negative.

Three things the doc spells out because they are easy to get wrong. iOS bounds samples while Android bounds records, so `limit: 1` on `HEART_RATE` can return more than one point. Android applies `recordingMethodsToFilter` after the limit; iOS folds it into the query. And a very large limit may exceed the platform's maximum page size and come back empty, which I documented rather than clamped since the cap is not exposed by connect-client. Clamping instead is easy if you would rather.

Also adds `isiOSAppOnVision` to the iOS device-info stub. `device_info_plus ^13.2.0` now resolves to a version requiring it as a non-null bool, so `IosDeviceInfo.fromMap` throws in `Health.configure` and 49 of 52 tests fail on a fresh clone. The new tests here cannot run without it, though it is unrelated and I can split it out.
